### PR TITLE
0.2/212 need an "unconfirmed" status query to exclude the payment pending status vouchers

### DIFF
--- a/app/Trader.php
+++ b/app/Trader.php
@@ -69,6 +69,9 @@ class Trader extends Model
                 case "unpaid":
                     $stateCondition = "reimbursed";
                     break;
+                case "unconfirmed":
+                    $stateCondition = "payment_pending";
+                    break;
                 default:
                     $stateCondition = null;
                     break;

--- a/app/Trader.php
+++ b/app/Trader.php
@@ -76,6 +76,7 @@ class Trader extends Model
                     $stateCondition = null;
                     break;
             }
+            // get all the vouchers that have a state record of $stateCondition
             $statedVoucherIDs = DB::table('vouchers')
                 ->leftJoin('voucher_states', 'vouchers.id', '=', 'voucher_states.voucher_id')
                 ->leftJoin('traders', 'vouchers.trader_id', '=', 'traders.id')


### PR DESCRIPTION
Invented and "unconfirmed" status query var handler that removes vouchers that are "payment_pending" or greater from the recorded vouchers list