### PR TITLE
1.3/exp custom rules for voucher validation

### DIFF
--- a/app/Http/Controllers/Store/BundleController.php
+++ b/app/Http/Controllers/Store/BundleController.php
@@ -83,30 +83,17 @@ class BundleController extends Controller
             $startval = intval($start_match['number']);
             $endval = intval($end_match['number']);
 
-            // Check for some error conditions before we generate
-            if ($start_match['shortcode'] !== $end_match['shortcode']) {
-                // Is the range all one shortcode?
-                $voucherCodes[] = $end_match[0];
-
-                return $this->redirectAfterRequest(["rangeShortcodeMismatch" => $voucherCodes], $registration);
-            } elseif ($startval > $endval) {
-                // Is the range in order?
-                $voucherCodes[] = $end_match[0];
-
-                return $this->redirectAfterRequest(["rangeOrder" => $voucherCodes], $registration);
-            } else {
-                // Generate codes!
-                for ($val = $startval+1; $val <= $endval; $val++) {
-                    // Assemble code, add to voucherCodes[]
-                    // We appear to be producing codes that are "0" str_pad on the left, to variable characters
-                    // We'll use the $start's numeric length as the value to pad to.
-                    $voucherCodes[] = $start_match['shortcode'] . str_pad(
-                        $val,
-                        strlen($start_match['number']),
-                        "0",
-                        STR_PAD_LEFT
-                    );
-                }
+            // Generate codes!
+            for ($val = $startval+1; $val <= $endval; $val++) {
+                // Assemble code, add to voucherCodes[]
+                // We appear to be producing codes that are "0" str_pad on the left, to variable characters
+                // We'll use the $start's numeric length as the value to pad to.
+                $voucherCodes[] = $start_match['shortcode'] . str_pad(
+                    $val,
+                    strlen($start_match['number']),
+                    "0",
+                    STR_PAD_LEFT
+                );
             }
         };
 
@@ -186,12 +173,6 @@ class BundleController extends Controller
                         break;
                     case "foreign":
                         $messages[] = "Action denied on a foreign voucher: " . join(', ', $values);
-                        break;
-                    case "rangeOrder":
-                        $messages[] = "Start and End out of order: " . join(', ', $values);
-                        break;
-                    case "rangeShortcodeMismatchError":
-                        $messages[] = "Start and End are different Sponsors: " . join(', ', $values);
                         break;
                     default:
                         $messages[] = 'There was an unknown error';

--- a/app/Http/Requests/StoreAppendBundleRequest.php
+++ b/app/Http/Requests/StoreAppendBundleRequest.php
@@ -32,7 +32,7 @@ class StoreAppendBundleRequest extends FormRequest
             // MUST be present, not null and string
             'start' => 'required|string|exists:vouchers,code',
             // MAY be present, nullable and string
-            'end' => 'nullable|string|exists:vouchers,code',
+            'end' => 'nullable|string|exists:vouchers,code|codeGreaterThan:start|sameSponsor:start',
         ];
 
         return $rules;

--- a/app/Http/Requests/StoreAppendBundleRequest.php
+++ b/app/Http/Requests/StoreAppendBundleRequest.php
@@ -31,7 +31,7 @@ class StoreAppendBundleRequest extends FormRequest
         $rules = [
             // MUST be present, not null and string
             'start' => 'required|string|exists:vouchers,code',
-            // MAY be present, nullable and string
+            // MAY be present, nullable, string, code exists, is GT start and same sponsor as start
             'end' => 'nullable|string|exists:vouchers,code|codeGreaterThan:start|sameSponsor:start',
         ];
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -23,23 +23,26 @@ class AppServiceProvider extends ServiceProvider
         // Recommended at https://laravel-news.com/laravel-5-4-key-too-long-error/
         Schema::defaultStringLength(191);
 
-        //Custom ARC form valdiation rules
+        //Custom ARC form valdiation rules - Incidentally, Laravel 5.5 has a much better system than this...
         Validator::extend('codeGreaterThan', function ($attribute, $value, $parameters, $validator) {
+            // Grab the regex matched array
             $val = \App\Voucher::splitShortcodeNumeric($value);
 
+            // Grab the content of the parameter we pass the rule in a roundabout fashion
             $otherVal = array_get(
                 $validator->getData(),
                 $parameters[0]
             );
 
+            // If it's actually a number-ish thing, not, say "invalidCode" or some-such
             if (!empty($otherVal)) {
                 $other = \App\Voucher::splitShortcodeNumeric($otherVal);
-                Log::info("boom" . $val["number"] . "|" . $other("number"));
+                Log::info("boom" . $val["number"] . "|" . $other["number"]);
+
                 return intval($val["number"]) > intval($other["number"]);
-            } else {
-                Log::info("boom");
-                return false;
             }
+            // Else "Nope"!
+            return false;
         });
 
         Validator::replacer('codeGreaterThan', function ($message, $attribute, $rule, $parameters) {

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,8 +2,10 @@
 
 namespace App\Providers;
 
+use Log;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\Validator;
 use Laracasts\Generators\GeneratorsServiceProvider;
 use Laravel\Dusk\DuskServiceProvider;
 use Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider;
@@ -20,6 +22,39 @@ class AppServiceProvider extends ServiceProvider
         // Fix for MySQL < v5.7.7 and MariaDB environs.
         // Recommended at https://laravel-news.com/laravel-5-4-key-too-long-error/
         Schema::defaultStringLength(191);
+
+        //Custom ARC form valdiation rules
+        Validator::extend('codeGreaterThan', function ($attribute, $value, $parameters, $validator) {
+            $val = \App\Voucher::splitShortcodeNumeric($value);
+
+            $otherVal = array_get(
+                $validator->getData(),
+                $parameters[0]
+            );
+
+            if (!empty($otherVal)) {
+                $other = \App\Voucher::splitShortcodeNumeric($otherVal);
+                Log::info("boom" . $val["number"] . "|" . $other("number"));
+                return intval($val["number"]) > intval($other["number"]);
+            } else {
+                Log::info("boom");
+                return false;
+            }
+        });
+
+        Validator::replacer('codeGreaterThan', function ($message, $attribute, $rule, $parameters) {
+            return str_replace(':other', $parameters[0], $message);
+        });
+
+        Validator::extend('sameSponsor', function ($attribute, $value, $parameters, $validator) {
+            $val = \App\Voucher::splitShortcodeNumeric($value);
+            $other = \App\Voucher::splitShortcodeNumeric($parameters[0]);
+            return $val['shortcode'] === $other['shortcode'];
+        });
+
+        Validator::replacer('sameSponsor', function ($message, $attribute, $rule, $parameters) {
+            return str_replace(':other', $parameters[0], $message);
+        });
     }
 
     /**

--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -86,6 +86,10 @@ return [
     'uploaded'             => 'The :attribute failed to upload.',
     'url'                  => 'The :attribute format is invalid.',
 
+    // ARC specific
+    'code_greater_than'    => 'The :attribute field must be greater than the :other field.',
+    'same_sponsor'         => 'The :attribute field must be the same sponsor as the :other field.',
+
     /*
     |--------------------------------------------------------------------------
     | Custom Validation Language Lines

--- a/tests/Unit/Controllers/Store/BundleControllerTest.php
+++ b/tests/Unit/Controllers/Store/BundleControllerTest.php
@@ -3,7 +3,6 @@
 
 namespace Tests\Unit\Controllers\Store;
 
-use Log;
 use Auth;
 use App\Registration;
 use App\Bundle;
@@ -101,7 +100,7 @@ class BundleControllerTest extends StoreTestCase
             // end is not higher than start
             [
                 "data" => ["start" => 'tst10001', 'end' => 'tst09999' ],
-                "outcome" => ["end" => "The end field must be greater than the the start field."]
+                "outcome" => ["end" => "The end field must be greater than the start field."]
             ],
         ];
 
@@ -122,8 +121,6 @@ class BundleControllerTest extends StoreTestCase
             // Dig out errors from Session
             $response->seeInSession('errors');
             $errors = Session::get("errors")->get($field);
-
-            Log::info(print_r($errors));
 
             // Check our specific message is present
             $this->assertContains($set['outcome'][$field], $errors);

--- a/tests/Unit/Controllers/Store/BundleControllerTest.php
+++ b/tests/Unit/Controllers/Store/BundleControllerTest.php
@@ -3,6 +3,7 @@
 
 namespace Tests\Unit\Controllers\Store;
 
+use Log;
 use Auth;
 use App\Registration;
 use App\Bundle;
@@ -74,24 +75,34 @@ class BundleControllerTest extends StoreTestCase
             ],
             // start is not present
             [
-                "data" => ['end' => 'tst0123457'],
+                "data" => ['end' => 'tst10001'],
                 "outcome" => ["start" => "The start field is required."]
             ],
             // start is present but null
             [
-                "data" => ["start" => '', 'end' => 'tst0123457'],
+                "data" => ["start" => '', 'end' => 'tst10001'],
                 "outcome" => ["start" => "The start field is required."]
             ],
             // start is not a valid voucher code
             [
-                "data" => ["start" => 'invalidVoucher', 'end' => 'tst0123457' ],
+                "data" => ["start" => 'invalidVoucher', 'end' => 'tst10001' ],
                 "outcome" => ["start" => "The selected start is invalid."]
             ],
             // end is not a valid voucher code
             [
-                "data" => ["start" => 'tst0123455', 'end' => 'invalidCode' ],
+                "data" => ["start" => 'tst09999', 'end' => 'invalidCode' ],
                 "outcome" => ["end" => "The selected end is invalid."]
-            ]
+            ],
+            // end is not the same shortcode as start
+            [
+                "data" => ["start" => 'tst09999', 'end' => 'txt10000' ],
+                "outcome" => ["end" => "The end field must be the same sponsor as the start field."]
+            ],
+            // end is not higher than start
+            [
+                "data" => ["start" => 'tst10001', 'end' => 'tst09999' ],
+                "outcome" => ["end" => "The end field must be greater than the the start field."]
+            ],
         ];
 
         $route = route('store.registration.voucher-manager', [ 'registration' => $this->registration->id ]);
@@ -111,6 +122,8 @@ class BundleControllerTest extends StoreTestCase
             // Dig out errors from Session
             $response->seeInSession('errors');
             $errors = Session::get("errors")->get($field);
+
+            Log::info(print_r($errors));
 
             // Check our specific message is present
             $this->assertContains($set['outcome'][$field], $errors);


### PR DESCRIPTION
Ok; Bonus weekend PR.

BundleController shouldn't be validating start and end field problems, as we have a FormRequest for that. I pulled the same-sponsor and code-is-greater-than-other-field checks into custom rules.
The rules need custom strings in the validation file to return responses.
The FormRequest calls those rules. 

The upshot will be that the voucher-manager *could* look in the errors messageBag for these two errors, and assign them to the correct field which is more appropriate. 