### PR TITLE
1.4/1094 list update pulse

### DIFF
--- a/public/store/css/main.css
+++ b/public/store/css/main.css
@@ -813,6 +813,10 @@ VOUCHER PAGES
   animation-name: slidein;
 }
 
+.pulse {
+	animation-name: pulse;
+}
+
 .fade-back {
   display: none;
 }
@@ -873,4 +877,10 @@ VOUCHER PAGES
   to {
     transform: translateX(0%);
   }
+}
+
+@keyframes pulse {
+	0% { transform: scale(1) }
+	50% { transform: scale(1.1) }
+	100% { transform: scale(1) }
 }

--- a/public/store/css/main.css
+++ b/public/store/css/main.css
@@ -814,6 +814,7 @@ VOUCHER PAGES
 }
 
 .pulse {
+	animation-duration: 1s;
 	animation-name: pulse;
 }
 

--- a/resources/views/store/manage_vouchers.blade.php
+++ b/resources/views/store/manage_vouchers.blade.php
@@ -112,8 +112,8 @@
                 </form>
                 <p class="center vh-spaced">You have added {{ $vouchers_amount }} vouchers</p>
                 <button id="collection-button" class="long-button">Go to voucher collection</button>
-                <div class="center">
-                    <span class="clickable-span">
+                <div class="center" id="vouchers-added">
+                    <span class="clickable-span" >
                         Vouchers added
                         <i class="fa fa-caret-down" aria-hidden="true"></i>
                     </span>
@@ -197,6 +197,11 @@
                     $('.allocation').addClass('fade-back');
                     e.preventDefault();
                 });
+
+                var vouchersInList = $('#vouchers tr').length;
+                if(vouchersInList > 1) { // the first tr contains the table head
+                    $('#vouchers-added').addClass('pulse');
+                }
 
                 var firstVoucher = $('#first-voucher');
                 var lastVoucher = $('#last-voucher');


### PR DESCRIPTION

Looking for a bit of feedback on this one... It seems like overkill to change the bundle controller to track what the bundle used to contain, so I'm just adding the animation if the list contains some vouchers. This means it fires on remove events as well, but that is still an update to the list's content. Let me know what you think 🙂 

![add](https://user-images.githubusercontent.com/32434620/47728577-887d2080-dc56-11e8-9faa-0509d27f26e6.gif)

https://trello.com/c/DM4K9bmM/1094-add-visual-signifier-when-voucher-list-updates-espcially-if-list-closed-e-v