### PR TITLE
1.4/1132 refactor to remove prepred allocated as voucherstates in favour of bundle as the disbursed entity

### DIFF
--- a/app/Bundle.php
+++ b/app/Bundle.php
@@ -17,11 +17,12 @@ class Bundle extends Model
      * @var array
      */
     protected $fillable = [
-        'registration_id',
         'entitlement',
+        'registration_id',
+        'collecting_carer_id',
         'disbursed_at',
-        'centre_id',
-        'family_id'
+        'disbursing_centre_id',
+        'disbursing_user_id',
     ];
 
     protected $rules = [

--- a/app/Bundle.php
+++ b/app/Bundle.php
@@ -118,14 +118,8 @@ class Bundle extends Model
 
         // try to Run the vouchers we know are in the DB
         $vouchers->each(
-            function (Voucher $voucher) use ($bundle, $errors) {
-                try {
-                    $voucher->setBundle($bundle);
-                } catch (SMException $e) {
-                    // May occur if the transition system disagrees with the transition
-                    $errors["transitions"][] = $voucher->code;
-                    // don't rethrow!
-                }
+            function (Voucher $voucher) use ($bundle) {
+                $voucher->bundle()->associate($bundle)->save();
             }
         );
 

--- a/app/Voucher.php
+++ b/app/Voucher.php
@@ -102,29 +102,6 @@ class Voucher extends Model
     }
 
     /**
-     * The methods we should call to remember to transition.
-     * Could probably be turned into an event listener?
-     *
-     * @param Bundle|null $bundle the model (or not) to bind to
-     * @return bool
-     */
-    public function setBundle(Bundle $bundle = null)
-    {
-        $transition = (isset($bundle))
-            ? "bundle"
-            : "unbundle-to-" . $this->getPriorState()->from;
-
-        // The transitionAllowed() will chuck an SMException as well as return false if we can't transition.
-        // We'll be catching that further up the call stack.
-        if ($this->transitionAllowed($transition)) {
-            $this->bundle()->associate($bundle);
-            $this->applyTransition($transition);
-            return true;
-        }
-        return false;
-    }
-
-    /**
      * The Sponsor that backs this voucher
      *
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo

--- a/config/state-machine.php
+++ b/config/state-machine.php
@@ -14,8 +14,6 @@ return [
             'ordered',
             'printed',
             'dispatched',
-            'prepared', // used for creating bundles of vouchers
-            'allocated', // to families
             'recorded', // submitted to shortlist
             'payment_pending', // shortlist completed
             'reimbursed', // paid out
@@ -39,32 +37,12 @@ return [
                 'from' => ['printed'],
                 'to' => 'dispatched',
             ],
-            'bundle' => [
-                'from' => ['printed','dispatched'],
-                'to' => 'prepared',
-            ],
-            'disburse' => [
-                'from' => ['prepared'],
-                'to' => 'allocated',
-            ],
-            'unbundle-to-printed' => [
-                'from' => ['prepared'],
-                'to' => 'printed',
-            ],
-            'unbundle-to-dispatched' => [
-                'from' => ['prepared'],
-                'to' => 'dispatched',
-            ],
             'lose' => [
                 'from' => ['dispatched'],
                 'to' =>  'lost',
             ],
-            'allocate' => [
-                'from' => ['dispatched'],
-                'to' =>  'allocated',
-            ],
             'collect' => [
-                'from' => ['printed','dispatched','allocated'],
+                'from' => ['printed','dispatched'],
                 'to' =>  'recorded',
             ],
             'reject-to-printed' => [
@@ -75,10 +53,6 @@ return [
                 'from' => ['recorded'],
                 'to' => 'dispatched',
             ],
-            'reject-to-allocated' => [
-                'from' => ['recorded'],
-                'to' => 'allocated',
-            ],
             'confirm' => [
                 'from' => ['recorded'],
                 'to' => 'payment_pending'
@@ -88,7 +62,7 @@ return [
                 'to' =>  'reimbursed',
             ],
             'expire' => [
-                'from' => ['allocated'],
+                'from' => ['dispatched', 'printed'],
                 'to' =>  'expired',
             ],
             'retire' => [

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -195,37 +195,7 @@ $factory->define(App\Bundle::class, function (Faker\Generator $faker, $attribute
         : $family->entitlement
     ;
 
-    // Allocations: The factory won't fix an allocation without a centre
-    // If there's an allocated_at, set it.
-    $allocated_at = isset($attributes['allocated_at'])
-        ? $attributes['allocated_at']
-        : null
-    ;
-
-    // $centre is the centre we created the bundle at
-    $allocating_centre = null;
-
-    // if there is one supplied, find it
-    if (isset($attributes['allocating_centre_id'])) {
-        $allocating_centre = App\Centre::find($attributes['allocating_centre_id']);
-    }
-
-    // if it's *still* null
-    if (!$allocating_centre) {
-        if (Auth::check() && Auth::user()->centre) {
-            // and we have an auth user centre, use that
-            $allocating_centre = Auth::user()->centre;
-        } elseif ($family) {
-            // or grab the family's registration centre
-            $allocating_centre = App\Centre::find($family->initial_centre_id);
-        } else {
-            // or, maybe make one?
-            $allocating_centre = factory(App\Centre::class)->create();
-        }
-    }
-
     return [
-        'allocating_centre_id' => $allocating_centre->id,
         'registration_id' => $registration->id,
         'entitlement' => $entitlement
     ];

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -274,12 +274,12 @@ $factory->defineAs(App\Voucher::class, 'requested', function ($faker) use ($fact
 });
 
 /**
- * Voucher with currentstate allocated.
+ * Voucher with currentstate dispatched.
  */
-$factory->defineAs(App\Voucher::class, 'allocated', function ($faker) use ($factory) {
+$factory->defineAs(App\Voucher::class, 'dispatched', function ($faker) use ($factory) {
     $voucher = $factory->raw(App\Voucher::class);
 
-    // Todo create the voucher_states on the road to allocated.
+    // Todo create the voucher_states on the road to dispatched.
     factory(App\VoucherState::class)->create();
     factory(App\VoucherState::class)->create([
         'transition' => 'print',
@@ -291,13 +291,8 @@ $factory->defineAs(App\Voucher::class, 'allocated', function ($faker) use ($fact
         'from' => 'printed',
         'to' => 'dispatched',
     ]);
-    factory(App\VoucherState::class)->create([
-        'transition' => 'allocate',
-        'from' => 'printed',
-        'to' => 'allocated',
-    ]);
     return array_merge($voucher, [
-        'currentstate' => 'allocated',
+        'currentstate' => 'dispatched',
     ]);
 });
 

--- a/database/migrations/2018_09_28_140458_add_user_type_to_voucher_states.php
+++ b/database/migrations/2018_09_28_140458_add_user_type_to_voucher_states.php
@@ -38,7 +38,6 @@ class AddUserTypeToVoucherStates extends Migration
                 'collect',
                 'reject-to-printed',
                 'reject-to-dispatched',
-                'reject-to-allocated',
                 'confirm'
             ) 
         ");
@@ -47,12 +46,7 @@ class AddUserTypeToVoucherStates extends Migration
             UPDATE voucher_states SET user_type = 'CentreUser' 
             WHERE transition
             IN (
-                'bundle',
-                'disburse',
-                'unbundle-to-printed',
-                'unbundle-to-dispatched',
-                'lose',
-                'allocate'
+                'lose'
             ) 
         ");
     }

--- a/database/migrations/2018_11_02_150330_add_disbursing_fields_to_bundle.php
+++ b/database/migrations/2018_11_02_150330_add_disbursing_fields_to_bundle.php
@@ -13,6 +13,12 @@ class AddDisbursingFieldsToBundle extends Migration
      */
     public function up()
     {
+        // We can drop the allocating_centre, it's not a thing
+        Schema::table('bundles', function (Blueprint $table) {
+            $table->dropForeign('bundles_allocating_centre_id_foreign');
+            $table->dropColumn('allocating_centre_id');
+        });
+
         Schema::table('bundles', function (Blueprint $table) {
 
             $table->integer('disbursing_user_id')
@@ -32,10 +38,6 @@ class AddDisbursingFieldsToBundle extends Migration
             $table->foreign('collecting_carer_id')
                 ->references('id')
                 ->on('carers');
-
-            // We can drop the allocating_centre, it's not a thing
-            $table->dropForeign('bundles_allocating_centre_id_foreign');
-            $table->dropColumn('allocating_centre_id');
         });
     }
 

--- a/database/migrations/2018_11_02_150330_add_disbursing_fields_to_bundle.php
+++ b/database/migrations/2018_11_02_150330_add_disbursing_fields_to_bundle.php
@@ -1,0 +1,58 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddDisbursingFieldsToBundle extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('bundles', function (Blueprint $table) {
+            $table->integer('disbursing_user_id')
+                ->after('registration_id')
+                ->unsigned()
+                ->nullable();
+
+            $table->integer('collecting_carer_id')
+                ->after('registration_id')
+                ->unsigned()
+                ->nullable();
+
+            $table->foreign('disbursing_user_id')
+                ->references('id')
+                ->on('centre_users');
+
+            $table->foreign('collecting_carer_id')
+                ->references('id')
+                ->on('carers');
+
+            // We can drop the allocating_centre, it's not a thing
+            Schema::table('bundles', function (Blueprint $table) {
+                $table->dropForeign('bundles_allocating_centre_id_foreign');
+                $table->dropColumn('allocating_centre_id');
+            });
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('bundles', function (Blueprint $table) {
+            $table->dropForeign('bundles_disbursing_user_id_foreign');
+            $table->dropColumn('disbursing_user_id');
+
+            $table->dropForeign('bundles_collecting_carer_id_foreign');
+            $table->dropColumn('collecting_carer_id');
+        });
+    }
+}

--- a/database/migrations/2018_11_02_150330_add_disbursing_fields_to_bundle.php
+++ b/database/migrations/2018_11_02_150330_add_disbursing_fields_to_bundle.php
@@ -14,29 +14,22 @@ class AddDisbursingFieldsToBundle extends Migration
     public function up()
     {
         Schema::table('bundles', function (Blueprint $table) {
-            $table->integer('disbursing_user_id')
-                ->after('registration_id')
-                ->unsigned()
-                ->nullable();
 
-            $table->integer('collecting_carer_id')
-                ->after('registration_id')
-                ->unsigned()
-                ->nullable();
+            $table->integer('disbursing_user_id')->unsigned()->nullable();
+            $table->integer('collecting_carer_id')->unsigned()->nullable();
+            /*
+                        $table->foreign('disbursing_user_id')
+                            ->references('id')
+                            ->on('centre_users');
 
-            $table->foreign('disbursing_user_id')
-                ->references('id')
-                ->on('centre_users');
-
-            $table->foreign('collecting_carer_id')
-                ->references('id')
-                ->on('carers');
+                        $table->foreign('collecting_carer_id')
+                            ->references('id')
+                            ->on('carers');
+            */
 
             // We can drop the allocating_centre, it's not a thing
-            Schema::table('bundles', function (Blueprint $table) {
-                $table->dropForeign('bundles_allocating_centre_id_foreign');
-                $table->dropColumn('allocating_centre_id');
-            });
+            $table->dropForeign('bundles_allocating_centre_id_foreign');
+            $table->dropColumn('allocating_centre_id');
         });
     }
 
@@ -48,10 +41,9 @@ class AddDisbursingFieldsToBundle extends Migration
     public function down()
     {
         Schema::table('bundles', function (Blueprint $table) {
-            $table->dropForeign('bundles_disbursing_user_id_foreign');
+//            $table->dropForeign('bundles_disbursing_user_id_foreign');
+//            $table->dropForeign('bundles_collecting_carer_id_foreign');
             $table->dropColumn('disbursing_user_id');
-
-            $table->dropForeign('bundles_collecting_carer_id_foreign');
             $table->dropColumn('collecting_carer_id');
         });
     }

--- a/database/migrations/2018_11_02_150330_add_disbursing_fields_to_bundle.php
+++ b/database/migrations/2018_11_02_150330_add_disbursing_fields_to_bundle.php
@@ -15,17 +15,23 @@ class AddDisbursingFieldsToBundle extends Migration
     {
         Schema::table('bundles', function (Blueprint $table) {
 
-            $table->integer('disbursing_user_id')->unsigned()->nullable();
-            $table->integer('collecting_carer_id')->unsigned()->nullable();
-            /*
-                        $table->foreign('disbursing_user_id')
-                            ->references('id')
-                            ->on('centre_users');
+            $table->integer('disbursing_user_id')
+                ->after('disbursing_centre_id')
+                ->unsigned()
+                ->nullable();
 
-                        $table->foreign('collecting_carer_id')
-                            ->references('id')
-                            ->on('carers');
-            */
+            $table->integer('collecting_carer_id')
+                ->after('registration_id')
+                ->unsigned()
+                ->nullable();
+
+            $table->foreign('disbursing_user_id')
+                ->references('id')
+                ->on('centre_users');
+
+            $table->foreign('collecting_carer_id')
+                ->references('id')
+                ->on('carers');
 
             // We can drop the allocating_centre, it's not a thing
             $table->dropForeign('bundles_allocating_centre_id_foreign');
@@ -41,10 +47,9 @@ class AddDisbursingFieldsToBundle extends Migration
     public function down()
     {
         Schema::table('bundles', function (Blueprint $table) {
-//            $table->dropForeign('bundles_disbursing_user_id_foreign');
-//            $table->dropForeign('bundles_collecting_carer_id_foreign');
-            $table->dropColumn('disbursing_user_id');
-            $table->dropColumn('collecting_carer_id');
+            $table->dropForeign('bundles_disbursing_user_id_foreign');
+            $table->dropForeign('bundles_collecting_carer_id_foreign');
+            $table->dropColumn(['disbursing_user_id', 'collecting_carer_id']);
         });
     }
 }

--- a/database/seeds/VouchersSeeder.php
+++ b/database/seeds/VouchersSeeder.php
@@ -46,11 +46,6 @@ class VouchersSeeder extends Seeder
                 //Progress these to dispatched.
                 $rvp_vouchers[$i-60]->applyTransition('dispatch');
             }
-
-            if ($rvp_vouchers[$i-60]->id < 11) {
-                //Progress these to allocated.
-                $rvp_vouchers[$i-60]->applyTransition('allocate');
-            }
         }
 
         // Transition one voucher to recorded by trader 1.

--- a/tests/Unit/Controllers/Api/TraderControllerTest.php
+++ b/tests/Unit/Controllers/Api/TraderControllerTest.php
@@ -33,7 +33,6 @@ class TraderControllerTest extends TestCase
             $v->applyTransition('order');
             $v->applyTransition('print');
             $v->applyTransition('dispatch');
-            $v->applyTransition('allocate');
             $v->trader_id = 1;
             $v->applyTransition('collect');
         }

--- a/tests/Unit/Controllers/Store/BundleControllerTest.php
+++ b/tests/Unit/Controllers/Store/BundleControllerTest.php
@@ -275,7 +275,7 @@ class BundleControllerTest extends StoreTestCase
             $voucher->applyTransition('order');
             $voucher->applyTransition('print');
             $voucher->applyTransition('dispatch');
-            $voucher->setBundle($currentBundle);
+            $voucher->bundle()->associate($currentBundle)->save();
         }
 
         // there should be 3 vouchers!

--- a/tests/Unit/Listeners/SendVoucherHistoryEmailTest.php
+++ b/tests/Unit/Listeners/SendVoucherHistoryEmailTest.php
@@ -48,7 +48,6 @@ class SendVoucherHistoryEmailTest extends TestCase
             $v->applyTransition('order');
             $v->applyTransition('print');
             $v->applyTransition('dispatch');
-            $v->applyTransition('allocate');
             $v->trader_id = 1;
             $v->applyTransition('collect');
         }

--- a/tests/Unit/Listeners/SendVoucherPaymentRequestEmailTest.php
+++ b/tests/Unit/Listeners/SendVoucherPaymentRequestEmailTest.php
@@ -46,7 +46,6 @@ class SendVoucherPaymentRequestEmailTest extends TestCase
             $v->applyTransition('order');
             $v->applyTransition('print');
             $v->applyTransition('dispatch');
-            $v->applyTransition('allocate');
             $v->trader_id = 1;
             $v->applyTransition('collect');
         }

--- a/tests/Unit/Listeners/StateHistoryManagerTest.php
+++ b/tests/Unit/Listeners/StateHistoryManagerTest.php
@@ -37,20 +37,19 @@ class StateHistoryManagerTest extends TestCase
         $v = factory(Voucher::class, 'requested')->create();
         $v->applyTransition('order');
         $v->applyTransition('print');
-        $v->applyTransition('dispatch');
 
         $state = $v->history()->get(null)->last();
         $this->assertEquals(Auth::user()->id, $state->user_id);
         $this->assertEquals(class_basename(Auth::user()), $state->user_type);
 
         Auth::login($this->centreUser);
-        $v->applyTransition('allocate');
+        $v->applyTransition('dispatch');
 
         $state = $v->history()->get(null)->last();
         $this->assertEquals(Auth::user()->id, $state->user_id);
         $this->assertEquals(class_basename(Auth::user()), $state->user_type);
 
-        // transition voucher from allocated to collected
+        // transition voucher from dispatched to collected
         Auth::login($this->user);
         $v->applyTransition('collect');
 

--- a/tests/Unit/Models/BundleModelTest.php
+++ b/tests/Unit/Models/BundleModelTest.php
@@ -25,9 +25,10 @@ class BundleModelTest extends TestCase
         $this->assertInstanceOf(Bundle::class, $b);
         $this->assertInternalType('integer', $b->registration_id);
         $this->assertInternalType('integer', $b->entitlement);
-        $this->assertInternalType('integer', $b->allocating_centre_id);
         // a blank bundle hasn't been disbursed.
+        $this->assertNull($b->collecting_carer_id);
         $this->assertNull($b->disbursing_centre_id);
+        $this->assertNull($b->disbursing_user_id);
         $this->assertNull($b->disbursed_at);
         // a blank bundle doesn't have vouchers.
         $this->assertEmpty($b->vouchers);

--- a/tests/Unit/Models/TraderModelTest.php
+++ b/tests/Unit/Models/TraderModelTest.php
@@ -70,7 +70,6 @@ class TraderModelTest extends TestCase
             $v->applyTransition('order');
             $v->applyTransition('print');
             $v->applyTransition('dispatch');
-            $v->applyTransition('allocate');
             $v->trader_id = 1;
             $v->applyTransition('collect');
         }
@@ -104,7 +103,6 @@ class TraderModelTest extends TestCase
             $v->applyTransition('order');
             $v->applyTransition('print');
             $v->applyTransition('dispatch');
-            $v->applyTransition('allocate');
             $v->trader_id = 1;
             $v->applyTransition('collect');
         }

--- a/tests/Unit/Models/VoucherModelTest.php
+++ b/tests/Unit/Models/VoucherModelTest.php
@@ -21,7 +21,7 @@ class VoucherModelTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->voucher = factory(Voucher::class, 'allocated')->create();
+        $this->voucher = factory(Voucher::class, 'dispatched')->create();
     }
 
     public function testAVoucherIsCreatedWithExpectedAttributes()
@@ -166,15 +166,15 @@ class VoucherModelTest extends TestCase
         $user = factory(User::class)->create();
         Auth::login($user);
 
-        // An allocated Voucher.
+        // A dispatched Voucher.
         $v1 = $this->voucher;
         // A reimbursed Voucher.
-        $v2 = factory(Voucher::class, 'allocated')->create();
+        $v2 = factory(Voucher::class, 'dispatched')->create();
         $v2->applyTransition('collect');
         $v2->applyTransition('confirm');
         $v2->applyTransition('payout');
         // A couple of Payment Pending Vouchers.
-        $v3 = factory(Voucher::class, 'allocated', 2)->create();
+        $v3 = factory(Voucher::class, 'dispatched', 2)->create();
         $v3[0]->applyTransition('collect');
         $v3[0]->applyTransition('confirm');
         $v3[1]->applyTransition('collect');

--- a/tests/Unit/Models/VoucherStateModelTest.php
+++ b/tests/Unit/Models/VoucherStateModelTest.php
@@ -86,18 +86,6 @@ class VoucherStateModelTest extends TestCase
         $this->assertEquals($voucher->currentstate, 'recorded');
     }
 
-    public function testAPrintedVoucherCanBeBundled()
-    {
-        Auth::login($this->user);
-        $voucher = factory(Voucher::class, 'requested')->create();
-
-        $voucher->applyTransition('order');
-        $voucher->applyTransition('print');
-        $voucher->applyTransition('bundle');
-
-        $this->assertEquals($voucher->currentstate, 'prepared');
-    }
-
     public function testADispatchedVoucherCanBeCollected()
     {
         Auth::login($this->user);
@@ -109,47 +97,6 @@ class VoucherStateModelTest extends TestCase
         $voucher->applyTransition('collect');
 
         $this->assertEquals($voucher->currentstate, 'recorded');
-    }
-
-    public function testADispatchedVoucherCanBeBundled()
-    {
-        Auth::login($this->user);
-        $voucher = factory(Voucher::class, 'requested')->create();
-
-        $voucher->applyTransition('order');
-        $voucher->applyTransition('print');
-        $voucher->applyTransition('dispatch');
-        $voucher->applyTransition('bundle');
-
-        $this->assertEquals($voucher->currentstate, 'prepared');
-    }
-
-    public function testAPreparedVoucherCanBeDisbursed()
-    {
-        Auth::login($this->user);
-        $voucher = factory(Voucher::class, 'requested')->create();
-
-        $voucher->applyTransition('order');
-        $voucher->applyTransition('print');
-        $voucher->applyTransition('bundle');
-        $voucher->applyTransition('disburse');
-
-        $this->assertEquals($voucher->currentstate, 'allocated');
-    }
-
-    public function testARecordedVoucherCanBeRejectedBackToAllocated()
-    {
-        Auth::login($this->user);
-        $voucher = factory(Voucher::class, 'requested')->create();
-
-        $voucher->applyTransition('order');
-        $voucher->applyTransition('print');
-        $voucher->applyTransition('dispatch');
-        $voucher->applyTransition('allocate');
-        $voucher->applyTransition('collect');
-        $voucher->applyTransition('reject-to-allocated');
-
-        $this->assertEquals($voucher->currentstate, 'allocated');
     }
 
     public function testARecordedVoucherCanBeRejectedBackToPrinted()
@@ -178,31 +125,4 @@ class VoucherStateModelTest extends TestCase
 
         $this->assertEquals($voucher->currentstate, 'dispatched');
     }
-
-    public function testAPreparedVoucherCanBeUnbundledBackToPrinted()
-    {
-        Auth::login($this->user);
-        $voucher = factory(Voucher::class, 'requested')->create();
-
-        $voucher->applyTransition('order');
-        $voucher->applyTransition('print');
-        $voucher->applyTransition('bundle');
-        $voucher->applyTransition('unbundle-to-printed');
-
-        $this->assertEquals($voucher->currentstate, 'printed');
-    }
-
-    public function testAPreparedVoucherCanBeUnbundledBackToDispatched()
-    {
-        Auth::login($this->user);
-        $voucher = factory(Voucher::class, 'requested')->create();
-
-        $voucher->applyTransition('order');
-        $voucher->applyTransition('print');
-        $voucher->applyTransition('bundle');
-        $voucher->applyTransition('unbundle-to-dispatched');
-
-        $this->assertEquals($voucher->currentstate, 'dispatched');
-    }
-
 }

--- a/tests/Unit/Routes/ApiRoutesTest.php
+++ b/tests/Unit/Routes/ApiRoutesTest.php
@@ -48,7 +48,6 @@ class ApiRoutesTest extends TestCase
             $v->applyTransition('order');
             $v->applyTransition('print');
             $v->applyTransition('dispatch');
-            $v->applyTransition('allocate');
         }
         $this->vouchers[1]->trader_id = 1;
         $this->vouchers[1]->applyTransition('collect');
@@ -119,7 +118,7 @@ class ApiRoutesTest extends TestCase
 
     public function testCollectVoucherRoute()
     {
-        // Get a valid allocated code.
+        // Get a valid code.
         $code = $this->vouchers[0]->code;
         $payload= [
             'transition' => 'collect',
@@ -207,7 +206,7 @@ class ApiRoutesTest extends TestCase
 
     public function testRejectToAllocateVoucherRoute()
     {
-        // Get a valid allocated code.
+        // Get a valid code.
         $code = $this->vouchers[0]->code;
         $payload= [
             'transition' => 'collect',


### PR DESCRIPTION
Lots of deleteing, as prepared and allocated are no longer voucher states.
Bundle takes on the task of tracking allocated vouchers and it's own disbursement state.