### PR TITLE
1.4/1128 change the way we store carers

### DIFF
--- a/app/Http/Controllers/Store/RegistrationController.php
+++ b/app/Http/Controllers/Store/RegistrationController.php
@@ -364,7 +364,7 @@ class RegistrationController extends Controller
         $registration = Registration::findOrFail($request->get('registration'));
 
         // Update primary carer.
-        $carerInput = (array) $request->get("carer");
+        $carerInput = (array) $request->get("pri_carer");
         $carerKey = key($carerInput);
         $carer = Carer::find($carerKey);
         if ($carer->name !== $carerInput[$carer->id]) {

--- a/app/Http/Controllers/Store/RegistrationController.php
+++ b/app/Http/Controllers/Store/RegistrationController.php
@@ -363,6 +363,10 @@ class RegistrationController extends Controller
         // Fetch Registration and Family
         $registration = Registration::findOrFail($request->get('registration'));
 
+        // NOTE: Following refactor where we needed to retain Carer ids.
+        // Possible that we might want to add flag to carer to ditinguish Main from Secondary,
+        // to simplify method below for sorting and updating carer entries.
+
         // Update primary carer.
         $carerInput = (array) $request->get("pri_carer");
         $carerKey = key($carerInput);
@@ -395,7 +399,7 @@ class RegistrationController extends Controller
             }
         }
 
-        // Create mew carers
+        // Create new carers
         $newCarers = array_map(
             function ($new_carer) {
                 return new Carer(['name' => $new_carer]);

--- a/app/Http/Requests/StoreUpdateRegistrationRequest.php
+++ b/app/Http/Requests/StoreUpdateRegistrationRequest.php
@@ -33,7 +33,7 @@ class StoreUpdateRegistrationRequest extends FormRequest
          */
         $rules = [
             // MUST be present; MUST be a not-null string
-            'carer.*' => 'required|string',
+            'pri_carer.*' => 'required|string',
             // MAY be present; MUST be a not-null string
             'sec_carers.*' => 'string',
             // MAY be present; MUST be a not-null string

--- a/app/Http/Requests/StoreUpdateRegistrationRequest.php
+++ b/app/Http/Requests/StoreUpdateRegistrationRequest.php
@@ -33,9 +33,11 @@ class StoreUpdateRegistrationRequest extends FormRequest
          */
         $rules = [
             // MUST be present; MUST be a not-null string
-            'carer' => 'required|string',
+            'carer.*' => 'required|string',
             // MAY be present; MUST be a not-null string
-            'carers.*' => 'string',
+            'sec_carers.*' => 'string',
+            // MAY be present; MUST be a not-null string
+            'new_carers.*' => 'string',
             // MAY be present; MUST be a date format of '2017-07'
             'children.*' => 'date_format:Y-m',
             // MAY be null (if not present) or 0||1

--- a/resources/views/store/create_registration.blade.php
+++ b/resources/views/store/create_registration.blade.php
@@ -34,7 +34,7 @@
                         @if(is_array(old('carers')) || (!empty(old('carers'))))
                             @foreach (old('carers') as $old_sec_carer )
                                 <tr>
-                                    <td><input name="carers[]" type="hidden" value="{{ $old_sec_carer }}">{{ $old_sec_carer }}</td>
+                                    <td><input name="carers[]" type="text" value="{{ $old_sec_carer }}" ></td>
                                     <td><button type="button" class="remove_field"><i class="fa fa-minus" aria-hidden="true"></i></button></td>
                                 </tr>
                             @endforeach
@@ -120,7 +120,7 @@
                     }
                     if (fields < maxFields) {
                         fields++;
-                        $(el).append('<tr><td><input name="carers[]" type="hidden" value="' + carer_el.val() + '" >' + carer_el.val() + '</td><td><button type="button" class="remove_field"><i class="fa fa-minus" aria-hidden="true"></i></button></td></tr>');
+                        $(el).append('<tr><td><input name="carers[]" type="text" value="' + carer_el.val() + '" ></td><td><button type="button" class="remove_field"><i class="fa fa-minus" aria-hidden="true"></i></button></td></tr>');
                         carer_el.val('');
                     }
                 });

--- a/resources/views/store/edit_registration.blade.php
+++ b/resources/views/store/edit_registration.blade.php
@@ -18,8 +18,8 @@
                 </div>
                 <div>
                     <label for="carer">Main carer</label>
-                    <span class="@if(!$errors->has('carer'))collapsed @endif invalid-error" id="carer-span">This field is required</span>
-                    <input id="carer" name="carer[{{ $pri_carer->id }}]" class="@if($errors->has('carer'))invalid @endif" type="text" value="{{ $pri_carer->name }}" autocomplete="off"
+                    <span class="@if(!$errors->has('pri_carer'))collapsed @endif invalid-error" id="carer-span">This field is required</span>
+                    <input id="carer" name="pri_carer[{{ $pri_carer->id }}]" class="@if($errors->has('pri_carer'))invalid @endif" type="text" value="{{ $pri_carer->name }}" autocomplete="off"
                            autocorrect="off" spellcheck="false">
                 </div>
                 <div>

--- a/resources/views/store/edit_registration.blade.php
+++ b/resources/views/store/edit_registration.blade.php
@@ -19,7 +19,7 @@
                 <div>
                     <label for="carer">Main carer</label>
                     <span class="@if(!$errors->has('carer'))collapsed @endif invalid-error" id="carer-span">This field is required</span>
-                    <input id="carer" name="carer" class="@if($errors->has('carer'))invalid @endif" type="text" value="{{ $pri_carer->name }}" autocomplete="off"
+                    <input id="carer" name="carer[{{ $pri_carer->id }}]" class="@if($errors->has('carer'))invalid @endif" type="text" value="{{ $pri_carer->name }}" autocomplete="off"
                            autocorrect="off" spellcheck="false">
                 </div>
                 <div>
@@ -27,7 +27,7 @@
                     <table id="carer_wrapper">
                         @foreach ( $sec_carers as $sec_carer )
                             <tr>
-                                <td><input name="carers[]" type="text"
+                                <td><input name="sec_carers[{{ $sec_carer->id }}]" type="text"
                                            value="{{ $sec_carer->name }}" ></td>
                                 <td>
                                     <button type="button" class="remove_field">
@@ -230,7 +230,7 @@
                     }
                     if (fields < maxFields) {
                         fields++;
-                        $(el).append('<tr><td><input name="carers[]" type="text" value="' + carer_el.val() + '" ></td><td><button type="button" class="remove_field"><i class="fa fa-minus" aria-hidden="true"></i></button></td></tr>');
+                        $(el).append('<tr><td><input name="new_carers[]" type="text" value="' + carer_el.val() + '" ></td><td><button type="button" class="remove_field"><i class="fa fa-minus" aria-hidden="true"></i></button></td></tr>');
                         carer_el.val('');
                     }
                 });

--- a/resources/views/store/edit_registration.blade.php
+++ b/resources/views/store/edit_registration.blade.php
@@ -27,8 +27,8 @@
                     <table id="carer_wrapper">
                         @foreach ( $sec_carers as $sec_carer )
                             <tr>
-                                <td><input name="carers[]" type="hidden"
-                                           value="{{ $sec_carer->name }}">{{ $sec_carer->name }}</td>
+                                <td><input name="carers[]" type="text"
+                                           value="{{ $sec_carer->name }}" ></td>
                                 <td>
                                     <button type="button" class="remove_field">
                                         <i class="fa fa-minus" aria-hidden="true"></i>
@@ -230,7 +230,7 @@
                     }
                     if (fields < maxFields) {
                         fields++;
-                        $(el).append('<tr><td><input name="carers[]" type="hidden" value="' + carer_el.val() + '" >' + carer_el.val() + '</td><td><button type="button" class="remove_field"><i class="fa fa-minus" aria-hidden="true"></i></button></td></tr>');
+                        $(el).append('<tr><td><input name="carers[]" type="text" value="' + carer_el.val() + '" ></td><td><button type="button" class="remove_field"><i class="fa fa-minus" aria-hidden="true"></i></button></td></tr>');
                         carer_el.val('');
                     }
                 });

--- a/tests/Feature/Store/EditPageTest.php
+++ b/tests/Feature/Store/EditPageTest.php
@@ -51,7 +51,7 @@ class EditPageTest extends StoreTestCase
         $pri_carer = $this->registration->family->carers->first();
         $this->actingAs($this->centreUser, 'store')
             ->visit(URL::route('store.registration.edit', [ 'id' => $this->registration ]))
-            ->seeElement('input[name="carer"][value="'. $pri_carer->name .'"]')
+            ->seeElement('input[id="carer"][value="'. $pri_carer->name .'"]')
         ;
     }
 
@@ -91,7 +91,7 @@ class EditPageTest extends StoreTestCase
         // See the names in the page
         foreach ($carers as $sec_carer) {
              $this->see($sec_carer->name)
-                 ->seeElement('input[type="hidden"][value="'. $sec_carer->name .'"]')
+                 ->seeElement('input[type="text"][value="'. $sec_carer->name .'"]')
                  ;
         }
     }
@@ -282,7 +282,6 @@ class EditPageTest extends StoreTestCase
                 $this->dontSeeElement('input[name="fm_diary"][checked]');
             }
         }
-
     }
 
     /** @test */
@@ -334,7 +333,6 @@ class EditPageTest extends StoreTestCase
                 $this->dontSeeElement('input[name="fm_privacy"][checked]');
             }
         }
-
     }
 
     /** @test */
@@ -522,7 +520,7 @@ class EditPageTest extends StoreTestCase
             ->visit(URL::route('store.registration.edit', $this->registration->id))
             ->dontSee('Remove this family')
         ;
-   }
+    }
 
     /** @test */
     public function itWillRejectLeavingWithoutAReason()
@@ -629,7 +627,7 @@ class EditPageTest extends StoreTestCase
             ->see('<td>0 yr, 11 mo</td>')
             ->see('<div class="warning">');
 
-        // Set Carbon date & time back 
+        // Set Carbon date & time back
         Carbon::setTestNow();
     }
 }

--- a/tests/Unit/Routes/StoreRoutesTest.php
+++ b/tests/Unit/Routes/StoreRoutesTest.php
@@ -170,16 +170,19 @@ class StoreRoutesTest extends StoreTestCase
             ->visit($edit_route)
         ;
 
-        $this->type("changedByTest", "carer")
+        // Need to find the pri_carer id
+        $pri_carer = $registration->family->carers->shift();
+
+        $this->type("changedByTest", "pri_carer[". $pri_carer->id ."]")
             ->press("Save Changes")
             ->seePageIs($edit_route)
             ->assertResponseStatus(200)
-            ->seeElement("input[value=changedByTest]")
+            ->seeElement("input[id=carer][value=changedByTest]")
         ;
 
         Auth::logout();
 
-        $this->type("**blanked**", "carer")
+        $this->type("**blanked**", "pri_carer[". $pri_carer->id ."]")
             ->press("Save Changes")
             ->seePageIs($login_route)
             ->assertResponseStatus(200)


### PR DESCRIPTION
Previously, we just erased the existing list of carers and rebuilt them whenever a change was made to the registration via the edit page. This naive solution was effective, but now we need to keep the id's constant as we record the collecting carer when they pickup vouchers at centres.

Thus we need to a) track actual new carers, b) amend any that changed c) permit the amending of the primary carer, d) remove any carers in the database that are not present in the data submitted.