### PR TITLE
last collection date now ordered by disbursement date, rather than ID

### DIFF
--- a/app/Http/Controllers/Store/BundleController.php
+++ b/app/Http/Controllers/Store/BundleController.php
@@ -40,6 +40,7 @@ class BundleController extends Controller
         // Find the last collected bundle.
         $lastCollectedBundle = $registration->bundles()
             ->whereNotNull('disbursed_at')
+            ->whereDate('disbursed_at', '<=', Carbon::today()->toDateString())
             ->orderBy('disbursed_at', 'desc')
             ->limit(1)
             ->first();

--- a/app/Http/Controllers/Store/BundleController.php
+++ b/app/Http/Controllers/Store/BundleController.php
@@ -40,7 +40,7 @@ class BundleController extends Controller
         // Find the last collected bundle.
         $lastCollectedBundle = $registration->bundles()
             ->whereNotNull('disbursed_at')
-            ->orderBy('id', 'desc')
+            ->orderBy('disbursed_at', 'desc')
             ->limit(1)
             ->first();
         ;


### PR DESCRIPTION
https://trello.com/c/hci1eYtp/1139-bug-last-collection-date-needs-to-be-found-by-nearest-previous-date-from-today-rather-than-id

🐸 