### PR TITLE
Prevent index page buttons wrapping.

### DIFF
--- a/public/store/css/main.css
+++ b/public/store/css/main.css
@@ -216,6 +216,10 @@ strong {
 	text-align: right;
 }
 
+.no-wrap {
+	white-space: nowrap;
+}
+
 .logout-button {
 	width: 125px;
 	min-height: 35px;

--- a/resources/views/store/index_registration.blade.php
+++ b/resources/views/store/index_registration.blade.php
@@ -34,7 +34,7 @@
                             <td class="pri_carer">{{ $registration->family->carers->first()->name }}</td>
                             <td class="center">{{ $registration->family->entitlement }}</td>
                             <td class="center">{{ $registration->family->rvid }}</td>
-                            <td class="right">
+                            <td class="right no-wrap">
                                 @if( !isset($registration->family->leaving_on) )
                                 <a href="{{ route("store.registration.voucher-manager", ['id' => $registration->id ]) }}" class="link">
                                     <div class="link-button link-button-small">


### PR DESCRIPTION

- Index page buttons now won't wrap even on narrow screens

https://trello.com/c/NhD7OQrE/1149-safari-styling-issue-with-voucher-and-edit-buttons-both-landscape-and-portrait

![image](https://user-images.githubusercontent.com/32434620/48570918-62fe4100-e8fd-11e8-9586-3da72094b09d.png)
