### PR TITLE
Make sure sponsor ids of CC User's centres match

### DIFF
--- a/database/seeds/CentreUsersSeeder.php
+++ b/database/seeds/CentreUsersSeeder.php
@@ -18,10 +18,22 @@ class CentreUsersSeeder extends Seeder
             "password" => bcrypt('store_pass'),
             "role" => "centre_user",
         ]);
+
+        // Attach an initial centre
         $user1->centres()->attach([
-            1 => ['homeCentre' => true],
-            2 => ['homeCentre' => false],
-            3 => ['homeCentre' => false],
+            1 => ['homeCentre' => true]
+        ]);
+
+        // Get the first centre's sponsor and make two more centres with the same sponsor
+        $sponsor_id = $user1->centres()->first()->sponsor()->first()->id;
+
+        $local_centre1 = factory(App\Centre::class)->create(['sponsor_id' => $sponsor_id]);
+        $local_centre2 = factory(App\Centre::class)->create(['sponsor_id' => $sponsor_id]);
+
+        // Attach the extra centres
+        $user1->centres()->attach([
+            $local_centre1->id  => ['homeCentre' => false],
+            $local_centre2->id  => ['homeCentre' => false],
         ]);
 
         $user2 = factory(App\CentreUser::class)->create([

--- a/database/seeds/CentreUsersSeeder.php
+++ b/database/seeds/CentreUsersSeeder.php
@@ -27,13 +27,12 @@ class CentreUsersSeeder extends Seeder
         // Get the first centre's sponsor and make two more centres with the same sponsor
         $sponsor_id = $user1->centres()->first()->sponsor()->first()->id;
 
-        $local_centre1 = factory(App\Centre::class)->create(['sponsor_id' => $sponsor_id]);
-        $local_centre2 = factory(App\Centre::class)->create(['sponsor_id' => $sponsor_id]);
+        $local_centres = factory(App\Centre::class, 2)->create(['sponsor_id' => $sponsor_id]);
 
         // Attach the extra centres
         $user1->centres()->attach([
-            $local_centre1->id  => ['homeCentre' => false],
-            $local_centre2->id  => ['homeCentre' => false],
+            $local_centres[0]->id  => ['homeCentre' => false],
+            $local_centres[1]->id  => ['homeCentre' => false],
         ]);
 
         $user2 = factory(App\CentreUser::class)->create([


### PR DESCRIPTION

- Adds two extra centres to the CC User that definitely have the same sponsor id as the first one.
- It might be nicer to check how many there are already, and only make more if we need to, and attach the lot in any case?

General Laravel guidance appreciated 🙂 

https://trello.com/c/O2kvdGXJ/1153-centre-user-switching-httpexception

![image](https://user-images.githubusercontent.com/32434620/48727527-601b8d00-ec2a-11e8-835f-0b5243fa22be.png)
