### PR TITLE
Sort bundles before creating DatePeriod

### DIFF
--- a/app/Http/Controllers/Store/HistoryController.php
+++ b/app/Http/Controllers/Store/HistoryController.php
@@ -14,7 +14,7 @@ class HistoryController extends Controller
     {
         $datesArray = [];
         $all_carers = $registration->family->carers->all();
-        $disbursedBundles = $registration->bundles()->disbursed()->get();
+        $disbursedBundles = $registration->bundles()->disbursed()->orderBy('disbursed_at', 'desc')->get();
 
         if ($disbursedBundles->count() > 0) {
             // Creates a weekly date array from first assigned voucher to today.


### PR DESCRIPTION

- Sort the bundles so that the correct time period is displayed.

Fixes https://trello.com/c/vO3cLMWE/1154-collection-history-weeks-displayed