### PR TITLE
1.4/1160 reset password red error message second crack

### DIFF
--- a/app/Http/Controllers/Store/Auth/ResetPasswordController.php
+++ b/app/Http/Controllers/Store/Auth/ResetPasswordController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Store\Auth;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use Illuminate\Foundation\Auth\ResetsPasswords;
+use Illuminate\Support\Str;
 use Password;
 
 class ResetPasswordController extends Controller
@@ -56,5 +57,23 @@ class ResetPasswordController extends Controller
         return view('store.auth.passwords.reset')->with(
             ['token' => $token, 'email' => $request->email]
         );
+    }
+
+    /**
+     * Reset the given user's password BUT unlike the base method, DON'T log them in
+     *
+     * @param  \Illuminate\Contracts\Auth\CanResetPassword  $user
+     * @param  string  $password
+     * @return void
+     */
+    protected function resetPassword($user, $password)
+    {
+        $user->forceFill([
+            'password' => bcrypt($password),
+            'remember_token' => Str::random(60),
+        ])->save();
+
+        // If we'd logged them in, then we'd end up redirected to dashboard by
+        // app/Http/Middleware/RedirectIfAuthenticated.
     }
 }

--- a/resources/views/store/auth/login.blade.php
+++ b/resources/views/store/auth/login.blade.php
@@ -17,8 +17,13 @@
         <div class="login-container">
             <h2>Log In</h2>
             @if ($errors->has('error_message'))
-                <div class="alert alert-danger">
+                <div class="alert alert-warning">
                     <strong>{{ $errors->first('error_message') }}</strong>
+                </div>
+            @endif
+            @if (session('status'))
+                <div class="alert alert-info">
+                    <strong>{{ session('status') }}</strong>
                 </div>
             @endif
             <form role="form" method="POST" action="{{ route('store.login') }}">


### PR DESCRIPTION
different approach to @Nikomus' branch. I think the issue is that on password reset we *by default* log a person in. This lead the middleware to throw them at the dashboard page.

However, the use of `login($user)` is done in the wrong context, the "default" of web from config/auth['defaults'] and it gets screwed up looking at teh wrong table for a second befire adopting the write context and trying again. 