### PR TITLE
Since it's not trivial to tell which domain we've logged into, just r…

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -53,7 +53,7 @@ class Handler extends ExceptionHandler
             // Note: this will also draw attention to the login form timing out.
             Auth::logout();
             return redirect()
-                ->guest(route('/login'))
+                ->guest('/login')
                 // We anticipate expiry to be the most common reason.
                 ->withErrors(['error_message' => trans('auth.expired')])
                 ;


### PR DESCRIPTION
…oute to /login.

This was probably the desired behaviour, but we accidentally used route(), which requires a route alias, not a path.

I can't find a way to trigger this behaviour in the test framework.

It can be tested by a dev doing `php artisan cache:clear` to wipe the session cookies, and then trying to log out, though attempting to automate that has no effect in the test framework.