### PR TITLE
new test for populated bundle

### DIFF
--- a/tests/Unit/Models/BundleModelTest.php
+++ b/tests/Unit/Models/BundleModelTest.php
@@ -9,7 +9,6 @@ use Auth;
 use App\Bundle;
 use App\Registration;
 use Carbon\Carbon;
-use ClassesWithParents\G;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
 
 class BundleModelTest extends TestCase


### PR DESCRIPTION
note: had to build models separately and pass attributes as using Registration from the Model Factory returns sub Models (Family, Carer) with attributes as strings which then breaks the type checking.

Carded this as a separate issue for investigation as advised by @charlesstrange2 