### PR TITLE
1.5 1232 checkbox spacing bug

### DIFF
--- a/resources/views/store/create_registration.blade.php
+++ b/resources/views/store/create_registration.blade.php
@@ -99,10 +99,10 @@
                         />
                         <label for="other">Other Local Criteria</label>
                     </div>
-                </div>
-                <div class="user-control">
-                    <input type="checkbox" class="styled-checkbox @if($errors->has('consent'))invalid @endif" id="privacy-statement" name="consent" @if( old('consent') ) checked @endif/>
-                    <label for="privacy-statement">Has the registration form been completed and signed?</label>
+                    <div class="user-control">
+                        <input type="checkbox" class="styled-checkbox @if($errors->has('consent'))invalid @endif" id="privacy-statement" name="consent" @if( old('consent') ) checked @endif/>
+                        <label for="privacy-statement">Has the registration form been completed and signed?</label>
+                    </div>
                 </div>
                 @if ( $errors->has('consent') )
                 <div class="alert-message error" id="registration-alert">


### PR DESCRIPTION

- Move control inside container

https://trello.com/c/BTrbKJKa/1232-styling-on-reminder-message-for-registration-form-checkbox-overlaps-message

![image](https://user-images.githubusercontent.com/32434620/50890062-583dc500-13f1-11e9-9971-960786dfec86.png)
