### PR TITLE
1.5/hotfix 1241 hotfix unable to print family sheets on live site as a fm user in centre 0

### DIFF
--- a/resources/views/store/dashboard.blade.php
+++ b/resources/views/store/dashboard.blade.php
@@ -21,7 +21,7 @@
                 </li>
             </a>
             @if (auth::user()->role != 'foodmatters_user')
-            <a href="{{ $print_route }}" target="_blank" >
+            <a href="{{ $print_route }}" target="_blank" rel="noopener noreferrer">
                 <li>
                     <img src="{{ asset('store/assets/print-light.svg') }}" name="print-registrations">
                     {{ $print_button_text }}

--- a/resources/views/store/dashboard.blade.php
+++ b/resources/views/store/dashboard.blade.php
@@ -20,12 +20,14 @@
                     Search for a family
                 </li>
             </a>
+            @if (auth::user()->role != 'foodmatters_user')
             <a href="{{ $print_route }}" target="_blank" >
                 <li>
                     <img src="{{ asset('store/assets/print-light.svg') }}" name="print-registrations">
                     {{ $print_button_text }}
                 </li>
             </a>
+            @endif
             @can( 'export', App\Registration::class )
             <a href="{{ URL::route('store.centres.registrations.summary') }}">
                 <li>


### PR DESCRIPTION
https://trello.com/c/A9HTm4Js/1241-reimplement-hotfix-patch-unable-to-print-family-sheets-on-live-site-as-a-fm-user-in-centre-0-vvv-e
(also added noopener/noreferrer on a target="_blank" link)