### PR TITLE
all instances of 'sponsor' replaced with 'area'

### DIFF
--- a/resources/views/service/centres/create.blade.php
+++ b/resources/views/service/centres/create.blade.php
@@ -5,9 +5,9 @@
     @include('service.includes.sidebar')
     <div id="main-content">
 
-        <h1>Add a sponsor</h1>
+        <h1>Add a Children's Centre</h1>
 
-        <p>Use the form below to add a new sponsor. Add their name and voucher prefix.</p>
+        <p>Use the form below to add a new children's centre. Add their name, voucher prefix, area and form.</p>
 
         <!-- ADD NEW POST ROUTE HERE eg. method="POST" action="{{ route('admin.vouchers.storebatch') }}" -->
         <form role="form" class="styled-form">
@@ -22,7 +22,7 @@
                     <input type="text" id="voucher_prefix" name="voucher_prefix" class="{{ $errors->has('voucher_prefix') ? 'error ' : '' }}uppercase" required>
                 </div>
                 <div class="select">
-                    <label for="sponsor">Sponsor</label>
+                    <label for="sponsor">Area</label>
                     <select name="sponsor" id="sponsor" class="{{ $errors->has('sponsor') ? 'error' : '' }}" required>
                         <option value="">Choose one</option>
                         @foreach ($sponsors as $sponsor)
@@ -34,9 +34,9 @@
                     <label for="form">Form</label>
                     <select name="form" id="form" class="{{ $errors->has('form') ? 'error' : '' }}" required>
                         <option value="">Choose one</option>
-                        @foreach (config('arc.print_preferences') as $preference)
-                            <option value="{{ $preference }}">{{ $preference }}</option>
-                        @endforeach
+                        {{-- TODO: get from config --}}
+                        <option value="collection">collection</option>
+                        <option value="individual">individual</option>
                     </select>
                 </div>
             </div>

--- a/resources/views/service/centres/index.blade.php
+++ b/resources/views/service/centres/index.blade.php
@@ -12,7 +12,7 @@
                 <tr>
                     <th>Name</th>
                     <th>RVID Prefix</th>
-                    <th>Sponsor</th>
+                    <th>Area</th>
                     <th>Form</th>
                 </tr>
             </thead>

--- a/resources/views/service/dashboard.blade.php
+++ b/resources/views/service/dashboard.blade.php
@@ -17,7 +17,7 @@
                 <li>View vouchers, or to add a new batch of vouchers</li>
                 <li>View, add and edit workers (using the 'View workers' link)</li>
                 <li>View and add centres</li>
-                <li>View and add sponsors</li>
+                <li>View and add areas</li>
             </ul>
         </div>
 

--- a/resources/views/service/includes/sidebar.blade.php
+++ b/resources/views/service/includes/sidebar.blade.php
@@ -9,8 +9,8 @@
         <li><a href="{{ url('/workers/create') }}"><span class="glyphicon glyphicon-plus"></span>Add workers</a></li>
         <li><a href="{{ url('/centres') }}"><span class="glyphicon glyphicon-th-list"></span>View children's centres</a></li>
         <li><a href="{{ url('/centres/create') }}"><span class="glyphicon glyphicon-plus"></span>Add children's centres</a></li>
-        <li><a href="{{ url('/sponsors') }}"><span class="glyphicon glyphicon-th-list"></span>View sponsors</a></li>
-        <li><a href="{{ url('/sponsors/create') }}"><span class="glyphicon glyphicon-plus"></span>Add sponsors</a></li>
+        <li><a href="{{ url('/sponsors') }}"><span class="glyphicon glyphicon-th-list"></span>View areas</a></li>
+        <li><a href="{{ url('/sponsors/create') }}"><span class="glyphicon glyphicon-plus"></span>Add areas</a></li>
 
         @unless(Config('app.url') === 'https://voucher-admin.alexandrarose.org.uk')
         <li>{{ Session::get('message') }}</li>

--- a/resources/views/service/sponsors/create.blade.php
+++ b/resources/views/service/sponsors/create.blade.php
@@ -5,9 +5,9 @@
     @include('service.includes.sidebar')
     <div id="main-content">
 
-        <h1>Add a sponsor</h1>
+        <h1>Add an area</h1>
 
-        <p>Use the form below to add a new sponsor. Add their name and voucher prefix.</p>
+        <p>Use the form below to add a new area. Add their name and voucher prefix.</p>
 
         <!-- ADD NEW POST ROUTE HERE eg. method="POST" action="{{ route('admin.vouchers.storebatch') }}" -->
         <form role="form" class="styled-form">

--- a/resources/views/service/sponsors/index.blade.php
+++ b/resources/views/service/sponsors/index.blade.php
@@ -6,7 +6,7 @@
     @include('service.includes.sidebar')
 
     <div id="main-content">
-        <h1>Sponsors</h1>
+        <h1>Areas</h1>
         <table class="table table-striped">
             <thead>
                 <tr>

--- a/resources/views/service/vouchers/create.blade.php
+++ b/resources/views/service/vouchers/create.blade.php
@@ -7,15 +7,15 @@
 
         <h1>Add a batch of voucher codes</h1>
 
-        <p>Use the form below to add a new batch of vouchers. Select a sponsor code, and then enter the starting and ending voucher code numbers.</p>
+        <p>Use the form below to add a new batch of vouchers. Select an area, and then enter the starting and ending voucher code numbers.</p>
 
         <form role="form" method="POST" action="{{ route('admin.vouchers.storebatch') }}" class="styled-form add-vouchers">
             {!! csrf_field() !!}
 
             <div class="select">
-                <label for="sponsor_id">Sponsor</label>
+                <label for="sponsor_id">Area</label>
                 <select name="sponsor_id" id="sponsor_id" class="{{ $errors->has('sponsor_id') ? 'has-error' : '' }}" required>
-                    <option value="">Please select a sponsor</option>
+                    <option value="">Please select an area</option>
                     @foreach ($sponsors as $sponsor)
                     <option value="{{ $sponsor->id }}">{{ $sponsor->name }}</option>
                     @endforeach

--- a/resources/views/service/vouchers/index.blade.php
+++ b/resources/views/service/vouchers/index.blade.php
@@ -19,7 +19,7 @@
                     <th>Trader ID</th>
                     <th>Voucher code</th>
                     <th>Status</th>
-                    <th>Sponsor ID</th>
+                    <th>Area ID</th>
                     <th>Created at</th>
                     <th>Updated at</th>
                     <th>Deleted at</th>


### PR DESCRIPTION
https://trello.com/c/V84dz7M6/1321-sponsor-area-in-all-user-facing-parts-of-the-app

config print prefs wasn't working here either, so i think it may not be working properly :{

🐐 