### PR TITLE
1.6/1335 store bad code problem

### DIFF
--- a/app/Http/Controllers/API/VoucherController.php
+++ b/app/Http/Controllers/API/VoucherController.php
@@ -56,7 +56,7 @@ class VoucherController extends Controller
             return response("Trader not found", 400);
         }
 
-        //remove spaces from voucher array values
+        //cleanup the codes
         $cleanedVouchers = Voucher::cleanCodes($request['vouchers']);
 
         //create unique vouchers

--- a/app/Http/Requests/StoreAppendBundleRequest.php
+++ b/app/Http/Requests/StoreAppendBundleRequest.php
@@ -49,7 +49,7 @@ class StoreAppendBundleRequest extends FormRequest
 
         foreach ($input as $key => $value) {
             $clean = Voucher::cleanCodes((array)$value);
-            $input[$key] = array_shift($clean);
+            $input[$key] = strtoupper((array_shift($clean)));
         }
         // replace old input with new input
         $this->replace($input);

--- a/public/store/css/main.css
+++ b/public/store/css/main.css
@@ -46,6 +46,10 @@ form {
 	margin: 0;
 }
 
+input.uppercase {
+	text-transform:uppercase
+}
+
 input[type="text"],
 input[type="month"],
 input[type="search"] {

--- a/resources/views/store/manage_vouchers.blade.php
+++ b/resources/views/store/manage_vouchers.blade.php
@@ -2,6 +2,10 @@
 
 @section('title', 'Voucher Manager')
 
+@section('hoist-head')
+    <script src="{{ asset('store/js/jquery-ui-1.12.1/jquery-ui.min.js')}}"></script>
+@endsection
+
 @section('content')
 
     @include('store.partials.navbar', ['headerTitle' => 'Voucher Manager'])
@@ -90,10 +94,10 @@
                     {!! csrf_field() !!}
                     <div class="alongside-container">
                         <label>First voucher
-                            <input id="first-voucher" name="start" type="text" autofocus>
+                            <input id="first-voucher" name="start" type="text" autofocus class="uppercase">
                         </label>
                         <label>Last voucher
-                            <input id="last-voucher" name="end" type="text">
+                            <input id="last-voucher" name="end" type="text" class="uppercase">
                         </label>
                         <button id="range-add" class="add-button" type="submit" name="range-add">
                             <i class="fa fa-plus" aria-hidden="true"></i>
@@ -105,7 +109,7 @@
                 {!! csrf_field() !!}
                     <div class="single-container">
                         <label for="single-voucher">Add individual vouchers
-                            <input id="single-voucher" name="start" type="text">
+                            <input id="single-voucher" name="start" type="text" class="uppercase">
                         </label>
                         <button id="single-add" class="add-button" type="submit" name="add-button">
                             <i class="fa fa-plus" aria-hidden="true"></i>
@@ -214,9 +218,6 @@
         </div>
     </div>
 
-    @section('hoist-head')
-        <script src="{{ asset('store/js/jquery-ui-1.12.1/jquery-ui.min.js')}}"></script>
-    @endsection
     <script type="text/javascript">
         $(document).ready(
             function () {
@@ -244,7 +245,7 @@
 
                 // Handle first in a range of vouchers
                 firstVoucher.keypress(function(e) {
-                    if(e.keyCode==13){
+                    if(e.keyCode===13){
                         e.preventDefault();
                         window.setTimeout(function() {
                             if(firstVoucher.val() !== ""){
@@ -256,7 +257,7 @@
 
                 // Handle last in a range of vouchers
                 lastVoucher.keypress(function(e) {
-                    if(e.keyCode==13){
+                    if(e.keyCode===13){
                         e.preventDefault();
                         window.setTimeout(function() {
                             if(firstVoucher.val() === "") {
@@ -272,7 +273,7 @@
 
                 // Handle a single voucher
                 singleVoucher.keypress(function(e) {
-                    if(e.keyCode==13){
+                    if(e.keyCode===13){
                         e.preventDefault();
                         window.setTimeout(function() {
                             $('#single-add').trigger('click');
@@ -282,10 +283,11 @@
 
                 // Browser backup for lack of datepicker support eg. Safari
                 // Reset back to English date format
-                if ($('#collected-on')[0].type != 'date')
-                    $('#collected-on').datepicker({ dateFormat: 'dd-mm-yyyy' }).val();
-
-                $('#collected-on').valueAsDate = new Date();
+                var collectedOn = $('#collected-on');
+                if (collectedOn[0].type !== 'date') {
+                    collectedOn.datepicker({dateFormat: 'dd-mm-yyyy'}).val();
+                }
+                collectedOn.valueAsDate = new Date();
             }
         );
     </script>

--- a/tests/Feature/Store/VoucherManagerTest.php
+++ b/tests/Feature/Store/VoucherManagerTest.php
@@ -55,9 +55,9 @@ class VoucherManagerTest extends StoreTestCase
 
         // Make some vouchers
         $this->testCodes = [
-            'tst09999',
-            'tst10000',
-            'tst10001'
+            'TST09999',
+            'TST10000',
+            'TST10001'
         ];
 
         Auth::login($this->fmUser);
@@ -117,14 +117,14 @@ class VoucherManagerTest extends StoreTestCase
     {
         // check we can bulk add vouchers
         $this->actingAs($this->fmUser, 'store')
-        ->visit(URL::route('store.registration.voucher-manager', [ 'id' => $this->registration ]))
-        ->type('tst09999', 'start')
-        ->type('tst10001', 'end')
-        ->press('range-add')
-        ->seePageIs(URL::route('store.registration.voucher-manager', [ 'id' => $this->registration ]))
-        ->see('tst09999')
-        ->see('tst10000')
-        ->see('tst10001')
+            ->visit(URL::route('store.registration.voucher-manager', [ 'id' => $this->registration ]))
+            ->type('tst09999', 'start')
+            ->type('tst10001', 'end')
+            ->press('range-add')
+            ->seePageIs(URL::route('store.registration.voucher-manager', [ 'id' => $this->registration ]))
+            ->see('TST09999')
+            ->see('TST10000')
+            ->see('TST10001')
         ;
         // Three vouchers and the delete all button.
         $this->assertEquals(4, count($this->crawler->filter('.delete-button')));
@@ -139,11 +139,11 @@ class VoucherManagerTest extends StoreTestCase
     {
         // check we can add a single voucher
         $this->actingAs($this->fmUser, 'store')
-        ->visit(URL::route('store.registration.voucher-manager', [ 'id' => $this->registration ]))
-        ->type('tst09999', 'start')
-        ->press('add-button')
-        ->seePageIs(URL::route('store.registration.voucher-manager', [ 'id' => $this->registration ]))
-        ->see('tst09999')
+            ->visit(URL::route('store.registration.voucher-manager', [ 'id' => $this->registration ]))
+            ->type('tst09999', 'start')
+            ->press('add-button')
+            ->seePageIs(URL::route('store.registration.voucher-manager', [ 'id' => $this->registration ]))
+            ->see('TST09999')
         ;
         // One voucher and the delete all button.
         $this->assertEquals(2, count($this->crawler->filter('.delete-button')));

--- a/tests/Unit/Controllers/Store/BundleControllerTest.php
+++ b/tests/Unit/Controllers/Store/BundleControllerTest.php
@@ -45,9 +45,9 @@ class BundleControllerTest extends StoreTestCase
 
         // Make some vouchers
         $this->testCodes = [
-            'tst09999',
-            'tst10000',
-            'tst10001'
+            'TST09999',
+            'TST10000',
+            'TST10001'
         ];
 
         Auth::login($this->centreUser);
@@ -323,9 +323,9 @@ class BundleControllerTest extends StoreTestCase
         Auth::login($this->centreUser);
         // Make some vouchers to bundle.
         $testCodes = [
-            'tst0123455',
-            'tst0123456',
-            'tst0123457'
+            'TST0123455',
+            'TST0123456',
+            'TST0123457'
         ];
         foreach ($testCodes as $testCode) {
             $voucher = factory(Voucher::class, 'requested')->create([
@@ -377,9 +377,9 @@ class BundleControllerTest extends StoreTestCase
         Auth::login($this->centreUser);
         // Make some vouchers to bundle.
         $testCodes = [
-            'tst0123455',
-            'tst0123456',
-            'tst0123457'
+            'TST0123455',
+            'TST0123456',
+            'TST0123457'
         ];
         foreach ($testCodes as $testCode) {
             $voucher = factory(Voucher::class, 'requested')->create([


### PR DESCRIPTION
We don't permit lowercase codes at the moment;
removed the ability to enter those on the voucher manager page. 

https://trello.com/c/f88iOgBT/1335-bug-store-lowercase-vouchers-are-rejected-as-errors-but-still-added