### PR TITLE
1.7/1303 revisit streaming/decrypting the MVL (V/EE) 

### DIFF
--- a/app/Http/Controllers/Store/VoucherController.php
+++ b/app/Http/Controllers/Store/VoucherController.php
@@ -39,8 +39,14 @@ class VoucherController extends Controller
         $file = fopen($disk->path($archiveName), 'r');
         $header = fread($file, SODIUM_CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_HEADERBYTES);
 
-        // Initialise the decryption stream with its initial header. For more documentation, SecretStreamWrapper.
-        $stream = sodium_crypto_secretstream_xchacha20poly1305_init_pull($header, SecretStreamWrapper::getKey());
+        try {
+            // Initialise the decryption stream with its initial header. For more documentation, SecretStreamWrapper.
+            $stream = sodium_crypto_secretstream_xchacha20poly1305_init_pull($header, SecretStreamWrapper::getKey());
+        } catch (\SodiumException $e) {
+            // TODO : This error copy needs some UI.
+            return redirect(URL::route('store.dashboard'))
+                ->with('error_message', "Sorry, the export file was unreadable. Please contact support.");
+        }
 
         // We want to only keep a small buffer in memory at any time, so our response will be streamed.
         return new StreamedResponse(function () use ($file, &$stream) {

--- a/app/Http/Controllers/Store/VoucherController.php
+++ b/app/Http/Controllers/Store/VoucherController.php
@@ -3,66 +3,28 @@
 namespace App\Http\Controllers\Store;
 
 use App\Http\Controllers\Controller;
+use App\Wrappers\SecretStreamWrapper;
 use Carbon\Carbon;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
-use Log;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use URL;
-use ZipArchive;
-use ZipStream\ZipStream;
 
 class VoucherController extends Controller
 {
     // This belongs here because it's largely about arranging vouchers
     public function exportMasterVoucherLog()
     {
-        $dashboard_route = URL::route('store.dashboard');
-
-        // Setup the Storage dir
+        // Setup the Storage dir.
         $disk = Storage::disk(config('arc.mvl_disk'));
         $archiveName = config('arc.mvl_filename');
 
-        // Check it's there.
+        // Check the log exists, so we can error-out before we declare a streamed response.
         if (!$disk->exists($archiveName)) {
             // Return to dashboard with an error that indicates we don't have a file.
-            return redirect($dashboard_route)
+            // TODO : This error copy needs some UI.
+            return redirect(URL::route('store.dashboard'))
                 ->with('error_message', "Sorry, couldn't find a current export. Please check the exporter ran on schedule");
-        }
-
-        // Open and test archive.
-        $storedZip = new ZipArchive();
-
-        // ZipArchive likes a fully qualified path.
-        $check = $storedZip->open($disk->path($archiveName), ZipArchive::CHECKCONS);
-
-        if ($check !== true) {
-            switch ($check) {
-                case ZipArchive::ER_NOZIP:
-                    $message = ('not a zip archive');
-                    break;
-                case ZipArchive::ER_INCONS:
-                    $message = ('consistency check failed');
-                    break;
-                case ZipArchive::ER_CRC:
-                    $message = ('checksum failed');
-                    break;
-                default:
-                    $message = ('error ' . $check);
-            }
-
-            // Log that error
-            Log::error(
-                // Leading `.` as url() gives a leading `/` and the storage is not off root
-                "ZipArchive cannot open archive at '." .
-                // Using url() to prevent revealing the disk tree
-                $disk->url($archiveName) .
-                "' as : " .
-                $message
-            );
-
-            // go back to dashboard with a
-            return redirect($dashboard_route)
-                ->with('error_message', "Sorry, the export file was unreadable. Please contact support.");
         }
 
         // Inject the original file last_modified into the d/l file name.
@@ -71,51 +33,51 @@ class VoucherController extends Controller
             "." . pathinfo($archiveName, PATHINFO_EXTENSION)
         ;
 
-        return new StreamedResponse(function () use ($storedZip) {
-            // Serve the user a zip with all of the files.
-            // We stream this to avoid duplicating everything in memory.
-            $zip = new ZipStream(null, [
-                ZipStream::OPTION_SEND_HTTP_HEADERS => false,
-                ZipStream::OPTION_OUTPUT_STREAM => fopen('php://output', 'w+'),
-            ]);
+        // TODO : refactor SecretStreamWrapper to handle reads, decoupling this controller from crypto code
 
-            // Iterate through files in the zip.
-            // TODO : Change to $zip->count() if we move to PHP 7.2
-            for ($i = 0; $i < $storedZip->numFiles; $i++) {
-                // Get the file's actual name.
-                $sourceName = $storedZip->getNameIndex($i);
+        // Do as much IO as we can comfortably before we begin streaming.
+        $file = fopen($disk->path($archiveName), 'r');
+        $header = fread($file, SODIUM_CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_HEADERBYTES);
 
-                // Open the stream for that file to decrypt it individually.
-                $fileStream = $storedZip->getStream($sourceName);
-                if (!$fileStream) {
-                    Log::error("ZipArchive cannot read compressed item '" . $sourceName . "'' by stream");
-                    continue;
+        // Initialise the decryption stream with its initial header. For more documentation, SecretStreamWrapper.
+        $stream = sodium_crypto_secretstream_xchacha20poly1305_init_pull($header, SecretStreamWrapper::getKey());
+
+        // We want to only keep a small buffer in memory at any time, so our response will be streamed.
+        return new StreamedResponse(function () use ($file, &$stream) {
+            do {
+                // Read the next message.
+                $part = fread($file, SecretStreamWrapper::MESSAGE_SIZE + SODIUM_CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_ABYTES);
+
+                if ($part === false) {
+                    // We couldn't read from the file. Log that as an error.
+                    Log::error("IO error when reading log");
+                    throw new \RuntimeException("IO error when reading log");
                 }
 
-                // Read the file contents to memory; bit of a farce but we don't want to extract to a temp file.
-                // TODO : Can we stream encryption / decryption to reduce memory usage to a buffer?
-                $contents = '';
-                while (!feof($fileStream)) {
-                    $contents .= fread($fileStream, 8192);
+                // Decrypt the message.
+                $part = sodium_crypto_secretstream_xchacha20poly1305_pull($stream, $part);
+
+                if ($part === false) {
+                    // Decryption failed. Log that as an error.
+                    Log::error("Decryption error when reading log");
+                    throw new \RuntimeException("Decryption error when reading log");
                 }
 
-                // Shut that off.
-                fclose($fileStream);
+                // Split the decrypted message into content and metadata.
+                list($message, $tag) = $part;
 
-                // Decrypt the file, if necessary.
-                if (pathinfo($sourceName, PATHINFO_EXTENSION) == 'enc') {
-                    $contents = decrypt($contents);
-                    $destName = pathinfo($sourceName, PATHINFO_FILENAME);
-                } else {
-                    $destName = $sourceName;
+                // The last message should be tagged as such, to ensure there was no tampering after encryption.
+                $eof = feof($file);
+                $lastMessage = $tag === SODIUM_CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_TAG_FINAL;
+                if ($eof != $lastMessage) {
+                    // We met the end of the file before the last message or vice-versa. Log that error.
+                    Log::error("Log read ended prematurely");
+                    throw new \RuntimeException("Log read ended prematurely");
                 }
 
-                // No compression, to start with.
-                $zip->addFile($destName, $contents, [], "store");
-            }
-
-            // Finish the Zip.
-            $zip->finish();
+                // Stream the decrypted content.
+                echo $message;
+            } while (!$eof); // While there is more to do, continue.
         }, 200, [
             'Content-Type' => 'application/x-zip',
             'Content-Disposition' => 'attachment; filename="'. $filename .'"',
@@ -123,6 +85,7 @@ class VoucherController extends Controller
             'Last-Modified' => Carbon::now()->format('D, d M Y H:i:s'),
             'Cache-Control' => 'private, no-cache',
             'Pragma' => 'no-cache',
+            // TODO : Estimate zip size for a progress bar on what is quite a large file
         ]);
     }
 }

--- a/app/Wrappers/SecretStreamWrapper.php
+++ b/app/Wrappers/SecretStreamWrapper.php
@@ -1,0 +1,187 @@
+<?php
+
+
+namespace App\Wrappers;
+
+use Illuminate\Support\Str;
+
+/**
+ * This stream wrapper allows the creation of a resource that will encrypt all data forwarded to another resource, such
+ * as a file or socket.
+ *
+ * Stream wrappers are fairly poorly documented in the PHP manual. They can be thought of as abstract files, which may
+ * or may not wrap another resource.
+ *
+ * https://www.php.net/manual/en/class.streamwrapper.php - for the "class" this one extends
+ * https://www.php.net/manual/en/stream.streamwrapper.example-1.php - for an example of another
+ * https://www.php.net/manual/en/stream.streamwrapper.example-1.php#99283 - for a more straight forward example of another
+ *
+ * The encryption used is provided by `libsodium`, a popular and robust library that can have its bindings compiled into
+ * PHP itself (as of version 7.2). The particular primitive is secret stream, which allows messages of known size from a
+ * larger source to be decrypted individually, with guarantees of order and completeness. This is important if we do not
+ * want the hold the entirety of a file in memory at any given time.
+ *
+ * Documentation is similarly poor for secret streams in PHP but examples are common for other languages. They can be
+ * thought of as encryption and decryption with state.
+ *
+ * https://libsodium.gitbook.io/doc/secret-key_cryptography/secretstream - description of the primitive and C examples
+ * https://github.com/php/php-src/blob/PHP-7.2.20/ext/sodium/libsodium.c#L3518 - the implementation of the methods for PHP
+ * https://github.com/php/php-src/blob/PHP-7.2.20/ext/sodium/tests/crypto_secretstream.phpt - expected outputs of PHP implementation
+ *
+ * NOTE: the class must be registered with @see stream_register_wrapper() before use as a protocol (`ssw://*`).
+ *
+ * @package App\Wrappers
+ */
+class SecretStreamWrapper
+{
+    // The size of each encrypted chunk of a file.
+    public const MESSAGE_SIZE = 1024 * 1024; // 1 mebibyte
+
+    // The stream context that the resource has been opened with.
+    public $context;
+
+    // The wrapped resource.
+    private $wrapped;
+
+    // The secret stream that we are wrapping with.
+    private $stream;
+
+    // We keep at least one message in a buffer so that we can output and mark the final message as final on closing.
+    private $buffer;
+
+    /**
+     * This would be triggered in scenarios such as `fopen("ssw://*")`. It establishes the resource.
+     *
+     * We setup the resource we're wrapping and the cryptography we're going to rely on, deriving our key from
+     * self::getKey().
+     *
+     * @param $path the full path provided to @see fopen() or similar
+     * @param $mode only "r" is supported
+     * @param $options some options encoded as bits
+     * @param $open
+     * @return bool whether opening was successful
+     */
+    public function stream_open($path, $mode, $options, &$open) {
+        // Check that we are in write mode.
+        if ($mode !== "w") {
+            if ($options & STREAM_REPORT_ERRORS) {
+                trigger_error('Secret stream wrapper may only be opened in "w" mode');
+            }
+            return false;
+        }
+
+        // Open wrapped resource. TODO : It would be nice if our parsing was more robust.
+        $parts = explode("://", $path);
+        if (count($parts) < 2) {
+            if ($options & STREAM_REPORT_ERRORS) {
+                trigger_error('Unable to parse wrapper-received URL');
+            }
+            return false;
+        }
+        $wrappedPath = implode("://", array_slice($parts, 1));
+        if (!($this->wrapped = fopen($wrappedPath, $mode))) {
+            if ($options & STREAM_REPORT_ERRORS) {
+                trigger_error('Wrapped path could not be opened');
+            }
+            return false;
+        }
+
+        // Initialise secret stream.
+        list($this->stream, $header) = sodium_crypto_secretstream_xchacha20poly1305_init_push(self::getKey());
+
+        // Write out initial header.
+        if (!fwrite($this->wrapped, $header)) {
+            if ($options & STREAM_REPORT_ERRORS) {
+                trigger_error('IO error when writing header');
+            }
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Handles writes to the resource, which we will encrypt. e.g. `fwrite()` would call this.
+     *
+     * @param $data the plaintext to write
+     * @return int how many bytes of input we used, else 0 if everything went wrong
+     */
+    public function stream_write($data) {
+        // Append data to our internal buffer.
+        $this->buffer .=  $data;
+
+        // Write out as many full-sized messages as we can without fully depleting the buffer.
+        if ($this->flushBuffer()) {
+            // We wrote everything provided to us.
+            return strlen($data);
+        }
+
+        // We failed to write.
+        return 0;
+    }
+
+    /**
+     * Flush out our final data and close all resources. e.g. `fclose()` would call this.
+     */
+    public function stream_close() {
+        // Write out data as encrypted messages until we have only the final message's data in the buffer.
+        $this->flushBuffer();
+
+        // Flush out the final message, tagged as such.
+        if (strlen($this->buffer) > 0) {
+            $encrypted = sodium_crypto_secretstream_xchacha20poly1305_push(
+                $this->stream,
+                $this->buffer,
+                '', // This is an inactive placeholder.
+                SODIUM_CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_TAG_FINAL
+            );
+            fwrite($this->wrapped, $encrypted); // TODO : Can an error here be caught somehow?
+        }
+
+        // Close our wrapped resource.
+        fclose($this->wrapped);
+    }
+
+    /**
+     * This is used to flush out our internal buffer, clearing everything until we only have enough left to send a final
+     * message, which we have to tag (and so send in stream_close()).
+     *
+     * @return bool whether all writes succeeded
+     */
+    private function flushBuffer() {
+        // While we can send a full-sized message and still have data left for the final message...
+        while (strlen($this->buffer) > self::MESSAGE_SIZE) {
+            // Write out a message's worth of data from the start of the buffer.
+            $encrypted = sodium_crypto_secretstream_xchacha20poly1305_push(
+                $this->stream,
+                substr($this->buffer, 0, self::MESSAGE_SIZE)
+            );
+            $this->buffer = substr($this->buffer, self::MESSAGE_SIZE);
+            if (!fwrite($this->wrapped, $encrypted)) return false;
+        }
+        return true;
+    }
+
+    /**
+     * Get the key that we will use for encryption, as defined in the config (and so probably by the environment
+     * variable APP_KEY.)
+     *
+     * @return string the key itself to use
+     */
+    public static function getKey() {
+        $key = config('app.key');
+
+        // Sometimes, the key is encoded in base64. Decrypt it if this is the case.
+        if (Str::startsWith($key, 'base64:')) {
+            $key = base64_decode(substr($key, 7));
+        }
+
+        // Check that the key is the write length.
+        // TODO : Can we guarantee that app.key will be configured as 32 random bytes?
+        if (strlen($key) !== SODIUM_CRYPTO_AEAD_CHACHA20POLY1305_KEYBYTES) {
+            throw new \RuntimeException("Randomly generated `app.key` wrong length / ill-defined");
+        }
+
+        return $key;
+    }
+}


### PR DESCRIPTION
# Progress

This PR implements the improvements suggested in #297, serving the Master Voucher Log with a streaming approach at every stage. As a result, memory usage rests comfortably at only a few megabytes and is now constant for any log size.

## New Flow

All spreadsheets are now compressed prior to encryption, as opposed to vice-versa.

Encryption and decryption occurs on output and input streams respectively, avoiding the need for either of these to hold the entire file contents in memory at any given time. This is achieved with:
* A stream wrapper for the log generation process
* Direct usage of the decryption streaming primitive in the log serving process.

### Log Creation

```
Database -> Spreadsheet -> ZIP Stream -> Secret Stream Wrapper -> File on Disk
```

### Log Serving

```
File on Disk -> Decryption Stream -> HTTP Response Stream
```

## Caveats
* The log's file size is fiddly to calculate prior to decryption, resulting in a download progress bar that lacks an estimation of progress and time remaining.
* A custom error page cannot be shown after the system has started serving the log, as an ongoing HTTP streaming response cannot be modified very semantically.
* The encryption library is not integrated into Laravel (but is part of the PHP standard library, as of PHP 7.2).

## Features
* The approach is scalable and should not require future optimisation.
* The log file is now compressed to a far smaller size, prior to encryption, reducing its use of memory, bandwidth and storage resources.
* The implementation of streaming encryption is highly reusable and could help reduce memory usage in other processes (including the generation of the file).