### PR TITLE
1.7/1283 Better validation to prevent "Robbing Vouchers" (VV/EE)

### DIFF
--- a/app/Bundle.php
+++ b/app/Bundle.php
@@ -123,10 +123,16 @@ class Bundle extends Model
             // Passing a pointer to $errors using "&", so we can change it, inside the loop.
             // Otherwise the variable is immutable.
             function (Voucher $voucher) use ($bundle, &$errors) {
-                // Check if the voucher is disbursed, because we can't change those.
-                if ($voucher->bundle && $voucher->bundle->disbursed_at !== null) {
+                // Check if the voucher is in another bundle, because we don't want to change those.
+                if ($voucher->bundle) {
                     // Throw it into an error.
-                    $errors["disbursed"][] = $voucher->code;
+                    if ($voucher->bundle->disbursed_at !== null) {
+                        // This voucher has been given out.
+                        $errors["disbursed"][] = $voucher->code;
+                    } else {
+                        // This voucher is in another bundle (but not necessarily given out).
+                        $errors["bundled"][] = $voucher->code;
+                    }
                 } else {
                     // Change its bundle
                     $voucher->bundle()->associate($bundle)->save();

--- a/app/Bundle.php
+++ b/app/Bundle.php
@@ -123,16 +123,13 @@ class Bundle extends Model
             // Passing a pointer to $errors using "&", so we can change it, inside the loop.
             // Otherwise the variable is immutable.
             function (Voucher $voucher) use ($bundle, &$errors) {
-                // Check if the voucher is in another bundle, because we don't want to change those.
-                if ($voucher->bundle) {
-                    // Throw it into an error.
-                    if ($voucher->bundle->disbursed_at !== null) {
-                        // This voucher has been given out.
-                        $errors["disbursed"][] = $voucher->code;
-                    } else {
-                        // This voucher is in another bundle (but not necessarily given out).
-                        $errors["bundled"][] = $voucher->code;
-                    }
+                // Ensure this voucher's bundle can be reassigned.
+                if ($voucher->bundle && $voucher->bundle->disbursed_at !== null) {
+                    // This voucher has already been given out.
+                    $errors["disbursed"][] = $voucher->code;
+                } else if ($voucher->bundle && $bundle !== null) {
+                    // Vouchers should not jump from another bundle without being manually removed first.
+                    $errors["bundled"][] = $voucher;
                 } else {
                     // Change its bundle
                     $voucher->bundle()->associate($bundle)->save();

--- a/app/Http/Controllers/Store/BundleController.php
+++ b/app/Http/Controllers/Store/BundleController.php
@@ -297,7 +297,36 @@ class BundleController extends Controller
                         $messages[] = "These vouchers have been given out: " . join(', ', $values);
                         break;
                     case "bundled":
-                        $messages[] = "These vouchers are already in a bundle: " . join(', ', $values);
+                        // Some vouchers were allocated to a family already. Partition these based on whether the user
+                        // has permission to remove them from the current family, so we can make a nice interactive
+                        // error message.
+
+                        $relevant = array();
+                        $inaccessible = array();
+
+                        foreach ($values as $voucher) {
+                            $registration = $voucher->bundle->registration;
+
+                            if (Auth::user()->isRelevantCentre($registration->centre)) {
+                                // The user can deallocate the voucher from its current family at this route.
+                                $route = route(
+                                    'store.registration.voucher-manager',
+                                    ['registration' => $registration->id]
+                                );
+
+                                $relevant[] = "<a href=\"$route\">" . e($voucher->code) . '</a>';
+                            } else {
+                                // The user does not have permission to remove the voucher's current allocation.
+                                $inaccessible[] = $voucher->code;
+                            }
+                        }
+
+                        // Generate error messages where vouchers of the sort existed, using unescaped HTML where necessary.
+                        $relevant && $messages[] = array(
+                            'html' => "These vouchers are currently allocated to a different family: " . join(', ', $relevant)
+                        );
+                        $inaccessible && $messages[] = "These vouchers are allocated to a family in a centre you can't access: " . join(', ', $inaccessible);
+
                         break;
                     case "empty":
                         if ($values) {
@@ -317,7 +346,7 @@ class BundleController extends Controller
             // Spit the basic error messages back
             return redirect($failRoute)
                 ->withInput()
-                ->with('error_message', join(', ', $messages) . '.');
+                ->with('error_messages', $messages);
         } else {
             // Otherwise, sure, return to the new view.
             return redirect($successRoute)

--- a/app/Http/Controllers/Store/BundleController.php
+++ b/app/Http/Controllers/Store/BundleController.php
@@ -296,8 +296,8 @@ class BundleController extends Controller
                     case "disbursed":
                         $messages[] = "These vouchers have been given out: " . join(', ', $values);
                         break;
-                    case "foreign":
-                        $messages[] = "Action denied on a different bundle: " . join(', ', $values);
+                    case "bundled":
+                        $messages[] = "These vouchers are already in a bundle: " . join(', ', $values);
                         break;
                     case "empty":
                         if ($values) {

--- a/resources/views/store/manage_vouchers.blade.php
+++ b/resources/views/store/manage_vouchers.blade.php
@@ -116,8 +116,8 @@
                         </button>
                     </div>
                 </form>
-                @includeWhen( $errors->count() > 0, 'store.partials.errors', ['error_array' => $errors->all()])
-                @includeWhen( Session::get('error_message'), 'store.partials.errors', ['error_array' => [Session::get('error_message')]])
+                @includeWhen($errors->count() > 0, 'store.partials.errors', ['error_array' => $errors->all()])
+                @includeWhen(Session::get('error_messages'), 'store.partials.errors', ['error_array' => Session::get('error_messages')])
                 <button id="collection-button"
                         class="long-button"
                         @if ($vouchers_amount == 0)

--- a/resources/views/store/partials/errors.blade.php
+++ b/resources/views/store/partials/errors.blade.php
@@ -4,7 +4,13 @@
     </div>
     <div>
         @foreach ($error_array as $error_text)
-            <p>{{ $error_text }}</p>
+            @if (is_array($error_text) && array_key_exists('html', $error_text))
+                {{-- Errors specified as pure-HTML will be embedded unsanitised --}}
+                <p>{!! $error_text['html'] !!}</p>
+            @else
+                {{-- All other strings will be protected against injection --}}
+                <p>{{ $error_text }}</p>
+            @endif
         @endforeach
     </div>
 </div>


### PR DESCRIPTION
## The Problem

When some vouchers are allocated to a second family, the original family silently loses them. While this allows vouchers to be moved between families easily, accidental moves are hard to reverse and poaching between centres is possible.

## The Ideal

* It should be possible to move vouchers between families easily
* The user should face a confirmatory step when they attempt to add vouchers to a second family
* The user should be unable to add vouchers to a second family when they do not have access to the original

## This PR

* Vouchers can no longer be moved directly between bundles. They must be removed from the original bundle first, manually.
* Appropriate error messages have been added for this scenario:
  * If the user can access the original holding family, the voucher code links to the family
  * If the user cannot access the original holding family, the voucher code is just listed
* All non-conflicting vouchers in the range are still allocated

![image](https://user-images.githubusercontent.com/2150762/64181444-5d5af300-ce5e-11e9-818c-584133c093eb.png)
