### PR TITLE
1.7/1371 Small improvements

### DIFF
--- a/tests/Feature/Store/ForgotPasswordPageTest.php
+++ b/tests/Feature/Store/ForgotPasswordPageTest.php
@@ -77,7 +77,7 @@ class ForgotPasswordPageTest extends StoreTestCase
         $headers = ['Referer' => 'www.google.com'];
 
         // Post, emulate clicking form button.
-        $this->post('/password/email', $post_data, $headers);
+        $this->post(route('store.password.email'), $post_data, $headers);
 
         // Expecting to *not* be at google.
         $this->dontSee('www.google.com')

--- a/tests/StoreTestCase.php
+++ b/tests/StoreTestCase.php
@@ -8,8 +8,6 @@ abstract class StoreTestCase extends BaseTestCase
 {
     use CreatesApplication;
 
-    protected $baseUrl = "http://arcv-store.test";
-
     /**
      * @param $selector string Selector string to find a bunch of elements
      * @param $text string String you're looking for

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,6 +7,4 @@ use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 abstract class TestCase extends BaseTestCase
 {
     use CreatesApplication;
-
-    protected $baseUrl = "http://arcv-service.test";
 }


### PR DESCRIPTION
## Fix

All tests use the `route` function to determine testing URLs, aside from one, which uses the hardcoded `baseUrl` attribute. This test fails consistently in environments with differing base URLs and is generally flaky in others.

This PR refactors the test to use the `route` function like every other test, hopefully remedying other issues with the test as a side-effect. In addition, the hardcoded `baseUrl` attribute is removed to prevent future tests introducing the same issue.

## Fixed

`ForgotPasswordPageTest::itCannotEffectRedirectWithAManipulatedRefererHeader`