### PR TITLE
1.7/1012 Improve tests (V/EE)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,10 @@ deploy:
       tags: true
 services:
 - mysql
+cache:
+  # Cache composer's cache, for fast installs
+  directories:
+  - $HOME/.composer/cache/files  
 env:
   global:
   # STAGING_USER

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -2,6 +2,7 @@
 
 namespace Tests;
 
+use Hash;
 use Illuminate\Contracts\Console\Kernel;
 
 trait CreatesApplication
@@ -18,6 +19,14 @@ trait CreatesApplication
         $app = require __DIR__.'/../bootstrap/app.php';
 
         $app->make(Kernel::class)->bootstrap();
+
+        /*
+         * `bcrypt` is intentionally a slow hash, for security.
+         * `bcrypt` can be made faster in testing environments where hardy security isn't necessary.
+         *
+         * This line reduces the duration of tests by ~30% on my machine.
+         */
+        Hash::setRounds(4);
 
         return $app;
     }


### PR DESCRIPTION
# Optimisations

## ~30% reduction in test runtime

bcrypt's hashing rounds have been reduced in the testing environment, where the strength is not needed. This is a [documented optimisation](https://driesvints.com/blog/two-tips-to-speedup-your-laravel-tests/) used [in the Laravel project itself](https://github.com/laravel/laravel/blob/master/phpunit.xml#L30).

## ~45 second reduction in Travis build runtime

Caching has been enabled in Travis for Composer's cache directory. As it isn't `vendor/` itself being cached, this shouldn't cause problems.

(caching is in effect on this branch's build but might not be on the PR's itself)