### PR TITLE
1.7/1389 Rules Broken

### DIFF
--- a/app/Services/VoucherEvaluator/Evaluators/VoucherEvaluator.php
+++ b/app/Services/VoucherEvaluator/Evaluators/VoucherEvaluator.php
@@ -118,7 +118,7 @@ class VoucherEvaluator extends AbstractEvaluator
             $credits = array_merge($credits, $child_status['credits']);
         }
 
-        $entitlement =  array_sum(array_column($credits, 'credits'));
+        $entitlement =  array_sum(array_column($credits, 'value'));
 
         return [
             'credits' => $credits,


### PR DESCRIPTION
This PR fixes the following:

## Problem

Every family had an entitlement of 0.

## Cause

When we were summing a family's credits to give their entitlement, we were looking at the wrong column.