### PR TITLE
1.7/1392 Adding a single voucher code fails

### DIFF
--- a/app/Http/Controllers/Service/Admin/VouchersController.php
+++ b/app/Http/Controllers/Service/Admin/VouchersController.php
@@ -57,7 +57,7 @@ class VouchersController extends Controller
         // Calulate the number of codes we need
         $numCodes = $input['end'] - $input['start'];
 
-        $step = null;
+        $step = 1;
         if ($numCodes > 1) {
             // Calculate the step, max = $maxStep.
             $step = ($numCodes < $maxStep)


### PR DESCRIPTION
See https://trello.com/c/VVkyXpUM/1392-adding-a-single-voucher-code-fails for description of bug.

## Cause of Bug

We create and save vouchers in several batches to accommodate adding in bulk. For any more than two vouchers, the batch size is variable and calculated. For 2 vouchers or less, it is constant. This constant had not been initialised, which led to the issue.

## Solution

The constant was initialised to its correct value.