### PR TITLE
1.7/1389 rules broken again

### DIFF
--- a/app/Services/VoucherEvaluator/EvaluatorFactory.php
+++ b/app/Services/VoucherEvaluator/EvaluatorFactory.php
@@ -103,12 +103,10 @@ class EvaluatorFactory
                     new ChildIsUnBorn($offsetDate),
                     new ChildIsAlmostBorn($offsetDate),
                     new ChildIsAlmostOne($offsetDate),
-                    new ChildIsAlmostSchoolAge($offsetDate),
                     new ChildIsAlmostExtendedAge($offsetDate)
                 ],
                 'credits' => [
                     new ChildIsUnderOne($offsetDate, 3),
-                    new ChildIsUnderSchoolAge($offsetDate, 3),
                     new ChildIsUnderExtendedAge($offsetDate, 3)
                 ]
             ],

--- a/tests/Unit/Services/VoucherEvaluator/VoucherEvaluatorTest.php
+++ b/tests/Unit/Services/VoucherEvaluator/VoucherEvaluatorTest.php
@@ -103,8 +103,8 @@ class VoucherEvaluatorTest extends TestCase
         $evaluation = $evaluator->evaluateChild($child);
         $credits = $evaluation["credits"];
 
-        // Check there's two, because child is not under one.
-        $this->assertEquals(2, count($credits));
+        // Check there's one, because child is not under one.
+        $this->assertEquals(1, count($credits));
 
         // Check the correct credit type is applied.
         $this->assertNotContains(self::CREDIT_TYPES['ChildIsUnderOne'], $credits, '');

--- a/tests/Unit/Services/VoucherEvaluator/VoucherEvaluatorTest.php
+++ b/tests/Unit/Services/VoucherEvaluator/VoucherEvaluatorTest.php
@@ -108,9 +108,8 @@ class VoucherEvaluatorTest extends TestCase
 
         // Check the correct credit type is applied.
         $this->assertNotContains(self::CREDIT_TYPES['ChildIsUnderOne'], $credits, '');
-        $this->assertContains(self::CREDIT_TYPES['ChildIsUnderSchoolAge'], $credits, '');
         $this->assertContains(self::CREDIT_TYPES['ChildIsUnderExtendedAge'], $credits, '');
-        $this->assertEquals(6, $evaluation["entitlement"]);
+        $this->assertEquals(3, $evaluation["entitlement"]);
     }
 
     /** @test */


### PR DESCRIPTION
The extended rules were crediting for both age 
=< school age,3
=< extended age, 3

so we had to remove the school age check and amend tests