### PR TITLE
1.7/1397 Incorrect wording in Your Family

### DIFF
--- a/resources/views/store/edit_registration.blade.php
+++ b/resources/views/store/edit_registration.blade.php
@@ -131,7 +131,14 @@
                             <ul>
                                 <li>Pregnancy - 3 vouchers</li>
                                 <li>Birth up to 1 year - 6 vouchers</li>
-                                <li>1 year up to school age - 3 vouchers</li>
+                                {{--
+                                TODO : This is not scalable; if this breaks or has to be extended, look at a better abstraction.
+                                --}}
+                                @if ( in_array($registration->centre->sponsor->shortcode, config('arc.extended_sponsors')) )
+                                <li>1 year up to secondary school - 3 vouchers</li>
+                                @else
+                                <li>1 year up to primary school - 3 vouchers</li>
+                                @endif
                             </ul>
                         </li>
                     </ul>


### PR DESCRIPTION
## Problem

The same description of voucher allocation rules was shown for registrations in centres with and without the new extended ruleset.

## Solution

A conditional has been added, using duplicated logic from the evaluator factory to determine what copy to show. It has been documented that this isn't scalable to more sets of rules.

## Further Thoughts

Should there be a test to ensure the copy alternates correctly?