### PR TITLE
1.7/1399 BUG: Laravel now requires {{{ }}} to show html

### DIFF
--- a/app/Http/Controllers/Store/BundleController.php
+++ b/app/Http/Controllers/Store/BundleController.php
@@ -13,6 +13,7 @@ use App\Http\Controllers\Controller;
 use Auth;
 use Carbon\Carbon;
 use Exception;
+use Illuminate\Support\HtmlString;
 use Log;
 
 class BundleController extends Controller
@@ -325,8 +326,8 @@ class BundleController extends Controller
                         }
 
                         // Generate error messages where vouchers of the sort existed, using unescaped HTML where necessary.
-                        $relevant && $messages[] = array(
-                            'html' => "These vouchers are currently allocated to a different family: " . join(', ', $relevant)
+                        $relevant && $messages[] = new HtmlString(
+                            "These vouchers are currently allocated to a different family: " . join(', ', $relevant)
                         );
                         $inaccessible && $messages[] = "These vouchers are allocated to a family in a centre you can't access: " . join(', ', $inaccessible);
 

--- a/resources/views/service/centres/create.blade.php
+++ b/resources/views/service/centres/create.blade.php
@@ -15,12 +15,12 @@
                 <div>
                     <label for="name" class="required">Name</label>
                     <input type="text" id="name" name="name" class="{{ $errors->has('name') ? 'error' : '' }}" required>
-                    @if($errors->has('name')) <label for="name" class="alert-danger">{{ implode("<br>", $errors->get('name')) }}</label> @endif
+                    @include('service.partials.validationMessages', array('inputName' => 'name'))
                 </div>
                 <div>
                     <label for="rvid_prefix" class="required">RVID prefix</label>
                     <input type="text" id="rvid_prefix" name="rvid_prefix" class="{{ $errors->has('rvid_prefix') ? 'error ' : '' }} uppercase" required>
-                    @if($errors->has('rvid_prefix')) <label for="rvid_prefix" class="alert-danger">{{ implode("<br>", $errors->get('rvid_prefix')) }}</label> @endif
+                    @include('service.partials.validationMessages', array('inputName' => 'rvid_prefix'))
                 </div>
                 <div class="select">
                     <label for="sponsor">Area</label>
@@ -30,7 +30,7 @@
                             <option value="{{ $sponsor->id }}">{{ $sponsor->name }}</option>
                         @endforeach
                     </select>
-                    @if($errors->has('sponsor')) <label for="sponsor" class="alert-danger">{{ implode("<br>", $errors->get('sponsor')) }}</label> @endif
+                    @include('service.partials.validationMessages', array('inputName' => 'sponsor'))
                 </div>
                 <div class="select">
                     <label for="print_pref">Printed Form</label>

--- a/resources/views/service/centreusers/create.blade.php
+++ b/resources/views/service/centreusers/create.blade.php
@@ -15,12 +15,12 @@
                 <div>
                     <label for="name" class="required">Name</label>
                     <input type="text" id="name" name="name" class="{{ $errors->has('name') ? 'error' : '' }}" required >
-                    @if($errors->has('name')) <label for="name" class="alert-danger">{{ implode("<br>", $errors->get('name')) }}</label> @endif
+                    @include('service.partials.validationMessages', array('inputName' => 'name'))
                 </div>
                 <div>
                     <label for="email" class="required">Email Address</label>
                     <input type="email" id="email" name="email" class="{{ $errors->has('email') ? 'error' : '' }}" required >
-                    @if($errors->has('email')) <label for="email" class="alert-danger">{{ implode("<br>", $errors->get('email')) }}</label> @endif
+                    @include('service.partials.validationMessages', array('inputName' => 'email'))
                 </div>
                 <div class="select">
                     <label for="worker_centre">Home Centre</label>
@@ -30,7 +30,7 @@
                             <option value="{{ $centre->id }}">{{ $centre->name }}</option>
                         @endforeach
                     </select>
-                    @if($errors->has('worker_centre')) <label for="worker_centre" class="alert-danger">{{ implode("<br>", $errors->get('worker_centre')) }}</label> @endif
+                    @include('service.partials.validationMessages', array('inputName' => 'worker_centre'))
                 </div>
                 <div id="alternatives" class="hidden">
                     <p><strong>Set Neighbours as Alternatives</strong></p>

--- a/resources/views/service/centreusers/edit.blade.php
+++ b/resources/views/service/centreusers/edit.blade.php
@@ -16,12 +16,12 @@
                 <div>
                     <label for="name" class="required">Name</label>
                     <input type="text" id="name" value="{{ $worker->name }}" name="name" class="{{ $errors->has('name') ? 'error' : '' }}" required>
-                    @if($errors->has('name')) <label for="name" class="alert-danger">{{ implode("<br>", $errors->get('name')) }}</label> @endif
+                    @include('service.partials.validationMessages', array('inputName' => 'name'))
                 </div>
                 <div>
                     <label for="email" class="required">Email Address</label>
                     <input type="email" id="email" name="email" value="{{ $worker->email }}" class="{{ $errors->has('email') ? 'error' : '' }}" required>
-                    @if($errors->has('email')) <label for="email" class="alert-danger">{{ implode("<br>", $errors->get('email')) }}</label> @endif
+                    @include('service.partials.validationMessages', array('inputName' => 'email'))
                 </div>
                 <div class="select">
                     <label for="worker_centre">Home Centre</label>
@@ -43,7 +43,7 @@
                         </optgroup>
                         @endforeach
                     </select>
-                    @if($errors->has('worker_centre')) <label for="worker_centre" class="alert-danger">{{ implode("<br>", $errors->get('worker_centre')) }}</label> @endif
+                    @include('service.partials.validationMessages', array('inputName' => 'worker_centre'))
                 </div>
                 <div class="checkboxes">
                     <div id="alternatives">

--- a/resources/views/service/deliveries/create.blade.php
+++ b/resources/views/service/deliveries/create.blade.php
@@ -27,22 +27,22 @@
                             @endforeach
                         @endforeach
                     </select>
-                    @if($errors->has('centre')) <label for="centre" class="alert-danger">{{ implode("<br>", $errors->get('centre')) }}</label> @endif
+                    @include('service.partials.validationMessages', array('inputName' => 'centre'))
                 </div>
                 <div>
                     <label for="voucher-start" class="required">Start Voucher</label>
                     <input type="text" id="voucher-start" name="voucher-start" value="{{ old('voucher-start') }}" class="{{ $errors->has('voucher-start') ? 'error' : '' }} uppercase" required >
-                    @if($errors->has('voucher-start')) <label for="voucher-start" class="alert-danger">{{ implode("<br>", $errors->get('voucher-start')) }}</label> @endif
+                    @include('service.partials.validationMessages', array('inputName' => 'voucher-start'))
                 </div>
                 <div>
                     <label for="voucher-end" class="required">End Voucher</label>
                     <input type="text" id="voucher-end" name="voucher-end" value="{{ old('voucher-end') }}" class="{{ $errors->has('voucher-end') ? 'error' : '' }} uppercase" required >
-                    @if($errors->has('voucher-end')) <label for="voucher-end" class="alert-danger">{{ implode("<br>", $errors->get('voucher-end')) }}</label> @endif
+                    @include('service.partials.validationMessages', array('inputName' => 'voucher-end'))
                 </div>
                 <div>
-                <label for="date-sent" class="required">Date Sent</label>
+                    <label for="date-sent" class="required">Date Sent</label>
                     <input type="date" id="date-sent" name="date-sent" value={{ old('date-sent') ?? date("Y-m-d") }} class="{{ $errors->has('date-sent') ? 'error' : '' }}" required >
-                    @if($errors->has('date-sent')) <label for="date-sent" class="alert-danger">{{ implode("<br>", $errors->get('date-sent')) }}</label> @endif
+                    @include('service.partials.validationMessages', array('inputName' => 'date-sent'))
                 </div>
             </div>
             <button type="submit" id="createDelivery">Create Delivery</button>

--- a/resources/views/service/partials/validationMessages.blade.php
+++ b/resources/views/service/partials/validationMessages.blade.php
@@ -1,0 +1,7 @@
+@if($errors->has($inputName))
+    @foreach ($errors->get($inputName) as $error)
+    <label role="alert" for="{{ $inputName }}" class="alert-danger">
+        {{ $error }}
+    </label>
+    @endforeach
+@endif

--- a/resources/views/service/sponsors/create.blade.php
+++ b/resources/views/service/sponsors/create.blade.php
@@ -15,12 +15,12 @@
                 <div>
                     <label for="name" class="required">Name</label>
                     <input type="text" id="name" name="name" class="{{ $errors->has('name') ? 'error' : '' }}" required>
-                    @if($errors->has('name')) <label for="name" class="alert-danger">{{ implode("<br>", $errors->get('name')) }}</label> @endif
+                    @include('service.partials.validationMessages', array('inputName' => 'name'))
                 </div>
                 <div>
                     <label for="voucher_prefix" class="required">Voucher Prefix</label>
                     <input type="text" id="voucher_prefix" name="voucher_prefix" class="{{ $errors->has('voucher_prefix') ? 'error ' : '' }} uppercase" required>
-                    @if($errors->has('voucher_prefix')) <label for="voucher_prefix" class="alert-danger">{{ implode("<br>", $errors->get('voucher_prefix')) }}</label> @endif
+                    @include('service.partials.validationMessages', array('inputName' => 'voucher_prefix'))
                 </div>
             </div>
             <button type="submit" id="createSponsor">Save</button>

--- a/resources/views/store/partials/errors.blade.php
+++ b/resources/views/store/partials/errors.blade.php
@@ -4,13 +4,7 @@
     </div>
     <div>
         @foreach ($error_array as $error_text)
-            @if (is_array($error_text) && array_key_exists('html', $error_text))
-                {{-- Errors specified as pure-HTML will be embedded unsanitised --}}
-                <p>{!! $error_text['html'] !!}</p>
-            @else
-                {{-- All other strings will be protected against injection --}}
-                <p>{{ $error_text }}</p>
-            @endif
+            <p>{{ $error_text }}</p>
         @endforeach
     </div>
 </div>


### PR DESCRIPTION
# Multiple Validation Messages

## Problem

When an input in Service has multiple validation messages, we want to show them on different lines. This is achieved by imploding them with the string `"<br>"` in PHP, manually, in the template.

As Blade sanitises and HTML encodes strings to prevent injection by default, the characters "<br>" are visible as text.

## Solution

This PR uses a Blade sub-template to handle multiple validation messages, generating a `<label>` for each one. This is more semantic and gives responsibility for the task to the deserving template engine.

# Manual Raw HTML Insertion

While making the previous change, I discovered that objects of type [`HtmlString`](https://stackoverflow.com/questions/42319470/what-is-htmlstring-used-for-in-laravel) will be as-is, unsanitised, into templates. We had a manual workaround for this in Store before, so I have replaced it with this better-supported approach.