### PR TITLE
1.7/1418 Error Message on Send Vouchers (CVA)

### DIFF
--- a/app/Http/Controllers/Service/Admin/DeliveriesController.php
+++ b/app/Http/Controllers/Service/Admin/DeliveriesController.php
@@ -122,6 +122,7 @@ class DeliveriesController extends Controller
                 Voucher::select('id')
                     ->where('currentState', 'printed')
                     ->whereNull('delivery_id')
+                    ->where('code', 'like', $start['shortcode'] . '%') // Just vouchers that start with our shortcode
                     ->whereBetween(
                         DB::raw("cast(replace(code, '{$start["shortcode"]}', '') as signed)"),
                         [$start["number"], $end["number"]]
@@ -156,6 +157,7 @@ class DeliveriesController extends Controller
                 // Get all the vouchers in the range and update them with the delivery Id and state
                 Voucher::where('currentState', 'printed')
                     ->whereNull('delivery_id')
+                    ->where('code', 'like', $start['shortcode'] . '%') // Just vouchers that start with our shortcode
                     ->whereBetween(
                         DB::raw("cast(replace(code, '{$start["shortcode"]}', '') as signed)"),
                         [$start["number"], $end["number"]]
@@ -168,6 +170,7 @@ class DeliveriesController extends Controller
         } catch (Throwable $e) {
             // Oops! Log that
             Log::error('Bad transaction for ' . __CLASS__ . '@' . __METHOD__ . ' by service user ' . Auth::id());
+            Log::error($e->getMessage()); // Log original error message too
             Log::error($e->getTraceAsString());
             // Throw it back to the user
             return redirect()

--- a/app/Http/Controllers/Service/Admin/DeliveriesController.php
+++ b/app/Http/Controllers/Service/Admin/DeliveriesController.php
@@ -122,7 +122,7 @@ class DeliveriesController extends Controller
                 Voucher::select('id')
                     ->where('currentState', 'printed')
                     ->whereNull('delivery_id')
-                    ->where('code', 'like', $start['shortcode'] . '%') // Just vouchers that start with our shortcode
+                    ->where('code', 'REGEXP', "^{$start["shortcode"]}[0-9]+\$") // Just vouchers that start with our shortcode
                     ->whereBetween(
                         DB::raw("cast(replace(code, '{$start["shortcode"]}', '') as signed)"),
                         [$start["number"], $end["number"]]
@@ -157,7 +157,7 @@ class DeliveriesController extends Controller
                 // Get all the vouchers in the range and update them with the delivery Id and state
                 Voucher::where('currentState', 'printed')
                     ->whereNull('delivery_id')
-                    ->where('code', 'like', $start['shortcode'] . '%') // Just vouchers that start with our shortcode
+                    ->where('code', 'REGEXP', "^{$start["shortcode"]}[0-9]+\$") // Just vouchers that start with our shortcode
                     ->whereBetween(
                         DB::raw("cast(replace(code, '{$start["shortcode"]}', '') as signed)"),
                         [$start["number"], $end["number"]]


### PR DESCRIPTION
## Problem

When sending vouchers, we need to check that:

* The vouchers are in the range provided
* The vouchers have the same shortcode

We check the former but not the latter.

Luckily, as this breaks our casting of the voucher code to an integer, the entire transaction is voided instead of additional vouchers being sent.

## Solution

This PR checks that it only touches vouchers that start with the same shortcode.

In addition, if the database transaction is voided, the reason why is logged in addition to the stack trace.