### PR TITLE
Find()->first() returns the wrong entity. Remove first()

### DIFF
--- a/app/Http/Requests/StoreUpdateRegistrationRequest.php
+++ b/app/Http/Requests/StoreUpdateRegistrationRequest.php
@@ -16,7 +16,7 @@ class StoreUpdateRegistrationRequest extends FormRequest
     public function authorize()
     {
         // Refuse updates to off-scheme users.
-        $registration = Registration::find($this->route('registration'))->first();
+        $registration = Registration::find($this->route('registration'));
         return (!isset($registration->family->leaving_on));
     }
 


### PR DESCRIPTION
Fixes dumb error in https://trello.com/c/qfCOEJJV/1426-hotfix-remove-find-first-in-authentication
where the addition of first() fetches family 1 to compare against.

Removing first will allow us to save the correct family, as it's not checking family 1 to see if we can save. 