### PR TITLE
1.8/1443 fix credentials in stacktraces

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -68,13 +68,14 @@ class Handler extends ExceptionHandler
      *
      * @throws Exception
      * @param  Exception  $e
-     * @return void
+     * @return mixed
      */
     public function report(Exception $e)
     {
         if (!$this->shallWeStackTrace($e)) {
             try {
                 // Should build an appropriate logger for our config;
+                // Alas, Log::shouldReceive can't detect this.
                 $logger = $this->container->make(LoggerInterface::class);
             } catch (Exception $ex) {
                 // Whoops, the logger didn't get made, throw the original exception
@@ -90,7 +91,7 @@ class Handler extends ExceptionHandler
                 .$e->getTrace()[0]['file']
             );
         } else {
-            parent::report($e);
+            return parent::report($e);
         }
     }
 

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -4,10 +4,20 @@ namespace App\Exceptions;
 
 use Auth;
 use Exception;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Auth\AuthenticationException;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use Illuminate\Http\Exceptions\HttpResponseException;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Redirector;
 use Illuminate\Session\TokenMismatchException;
+use Illuminate\Validation\ValidationException;
+use League\OAuth2\Server\Exception\OAuthServerException;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 
 class Handler extends ExceptionHandler
@@ -18,33 +28,78 @@ class Handler extends ExceptionHandler
      * @var array
      */
     protected $dontReport = [
-        \Illuminate\Auth\AuthenticationException::class,
-        \Illuminate\Auth\Access\AuthorizationException::class,
-        \Symfony\Component\HttpKernel\Exception\HttpException::class,
-        \Illuminate\Database\Eloquent\ModelNotFoundException::class,
-        \Illuminate\Session\TokenMismatchException::class,
-        \Illuminate\Validation\ValidationException::class,
+        AuthenticationException::class,
+        AuthorizationException::class,
+        HttpException::class,
+        ModelNotFoundException::class,
+        TokenMismatchException::class,
+        ValidationException::class,
     ];
+
+    // These produce a single line log
+    protected $dontStackTrace = [
+        HttpResponseException::class,
+        MethodNotAllowedHttpException::class,
+        OAuthServerException::class,
+    ];
+
+    /**
+     * Check an exception is worth a stacktrace
+     *
+     * @param Exception $e Exception
+     * @return bool;
+     */
+    protected function shallWeStackTrace(Exception $e)
+    {
+        if (config('app.env') === 'production') {
+            foreach ($this->dontStackTrace as $type) {
+                if ($e instanceof $type) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
 
     /**
      * Report or log an exception.
      *
      * This is a great spot to send exceptions to Sentry, Bugsnag, etc.
      *
-     * @param  \Exception  $exception
+     * @throws Exception
+     * @param  Exception  $e
      * @return void
      */
-    public function report(Exception $exception)
+    public function report(Exception $e)
     {
-        parent::report($exception);
+        if (!$this->shallWeStackTrace($e)) {
+            try {
+                // Should build an appropriate logger for our config;
+                $logger = $this->container->make(LoggerInterface::class);
+            } catch (Exception $ex) {
+                // Whoops, the logger didn't get made, throw the original exception
+                throw $e;
+            }
+            // Poor man's one-line error; If you see lots of these, investigate.
+            $logger->error(
+                get_class($e). ": ".
+                $e->getTrace()[0]['function']
+                .' on line '
+                . $e->getTrace()[0]['line']
+                .' of file '
+                .$e->getTrace()[0]['file']
+            );
+        } else {
+            parent::report($e);
+        }
     }
 
     /**
      * Render an exception into an HTTP response.
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \Exception  $exception
-     * @return \Illuminate\Http\Response|Response
+     * @param  Request  $request
+     * @param  Exception  $exception
+     * @return RedirectResponse|Redirector|Response
      */
     public function render($request, Exception $exception)
     {
@@ -73,8 +128,8 @@ class Handler extends ExceptionHandler
     /**
      * Convert an authentication exception into an unauthenticated response.
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \Illuminate\Auth\AuthenticationException  $exception
+     * @param  Request  $request
+     * @param AuthenticationException $exception
      * @return \Illuminate\Http\Response
      */
     protected function unauthenticated($request, AuthenticationException $exception)

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "ramsey/uuid": "^3.6",
         "sebdesign/laravel-state-machine": "^2.0",
         "symfony/event-dispatcher": "4.2.11",
-        "tom-lingham/searchy": "2.*"
+        "tom-lingham/searchy": "2.*",
+        "ext-http": "*"
     },
     "require-dev": {
         "barryvdh/laravel-ide-helper": "^2.4",

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,7 @@
         "ramsey/uuid": "^3.6",
         "sebdesign/laravel-state-machine": "^2.0",
         "symfony/event-dispatcher": "4.2.11",
-        "tom-lingham/searchy": "2.*",
-        "ext-http": "*"
+        "tom-lingham/searchy": "2.*"
     },
     "require-dev": {
         "barryvdh/laravel-ide-helper": "^2.4",

--- a/tests/Unit/Exceptions/ExceptionHandlerTest.php
+++ b/tests/Unit/Exceptions/ExceptionHandlerTest.php
@@ -2,25 +2,68 @@
 
 namespace Tests\Unit\Controllers\Store;
 
+use App\Exceptions\Handler;
+use Illuminate\Container\Container;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Http\Exceptions\HttpResponseException;
+use Illuminate\Support\Facades\Config;
+use League\OAuth2\Server\Exception\OAuthServerException;
+use ReflectionClass;
+use ReflectionException;
+use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 use Tests\StoreTestCase;
 
 class ExceptionHandlerTest extends StoreTestCase
 {
 
-    use DatabaseMigrations;
-
-    protected function setUp()
+    /** @test  */
+    public function itShouldNotStackTracesInProduction()
     {
-        //
+        // Set the exceptions to test
+        $exceptions = [
+            new OAuthServerException('', 4, "exception"),
+        ];
+
+        // get our current config.
+        $old_config = config('app.env');
+
+        // Get the Handler instance.
+        $handler = Container::getInstance()->make(Handler::class);
+
+        try {
+            foreach ($exceptions as $exception) {
+                Config::set('app.env', 'production');
+                $this->assertFalse(
+                    $this->invokeMethod($handler, 'shallWeStackTrace', [$exception])
+                );
+
+                // This shouldn't run in production, but just to check...
+                if ($old_config !== 'production') {
+                    Config::set('app.env', $old_config);
+                    $this->assertTrue(
+                        $this->invokeMethod($handler, 'shallWeStackTrace', [$exception])
+                    );
+                }
+            }
+        } catch (ReflectionException $e) {
+            // Just catch it.
+        }
     }
 
-    /** @test  */
-    public function itDoesNotStackTraceInProduction()
+    /**
+     * Call protected/private method of a class using Reflection
+     *
+     * @param object &$object    Instantiated object that we will run method on.
+     * @param string $methodName Method name to call
+     * @param array  $parameters Array of parameters to pass into method.
+     * @throws ReflectionException
+     * @return mixed Method return.
+     */
+    public function invokeMethod(&$object, $methodName, array $parameters = array())
     {
-        // set "production" mode
-        // for each stacktrace in handler#s list
-        //   call an exception
-        //   assert log has one extra line
+        $reflection = new ReflectionClass(get_class($object));
+        $method = $reflection->getMethod($methodName);
+        $method->setAccessible(true);
+        return $method->invokeArgs($object, $parameters);
     }
 }

--- a/tests/Unit/Exceptions/ExceptionHandlerTest.php
+++ b/tests/Unit/Exceptions/ExceptionHandlerTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Unit\Controllers\Store;
+
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Tests\StoreTestCase;
+
+class ExceptionHandlerTest extends StoreTestCase
+{
+
+    use DatabaseMigrations;
+
+    protected function setUp()
+    {
+        //
+    }
+
+    /** @test  */
+    public function itDoesNotStackTraceInProduction()
+    {
+        // set "production" mode
+        // for each stacktrace in handler#s list
+        //   call an exception
+        //   assert log has one extra line
+    }
+}


### PR DESCRIPTION
Slightly sad that i cant test exception logs to the file - `Log::shoudlReceive()` can't detect the way the exception handling system invokes it's own logger, rather than the Log interface. This means the mocker can't easily intercept. 

Have tried to track the decision to log full stacks or not with some reflection instead.

https://trello.com/c/zxWFWUfd/1443-fix-for-security-issue-from-14-11-2019-vvv-ee