### PR TITLE
Move manage voucher button to more logical location

### DIFF
--- a/public/store/css/main.css
+++ b/public/store/css/main.css
@@ -651,6 +651,7 @@ REGISTER PAGE
 }
 
 .long-button {
+	display: block;
 	margin: 1rem;
 	width: calc(100% - 2rem);
 }

--- a/resources/views/store/edit_registration.blade.php
+++ b/resources/views/store/edit_registration.blade.php
@@ -92,11 +92,6 @@
                     </table>
                 </div>
                 <button class="long-button submit" type="submit">Save Changes</button>
-                <a href="{{ route("store.registration.voucher-manager", ['id' => $registration->id ]) }}" class="link">
-                    <div class="link-button link-button-large">
-                        <i class="fa fa-ticket button-icon" aria-hidden="true"></i>Go to voucher manager
-                    </div>
-                </a>
             </div>
 
             <div class="col collect short-height">
@@ -164,6 +159,11 @@
                 <button class="long-button" onclick="window.open( '{{ URL::route("store.registration.print", ["id" => $registration->id]) }}'); return false">
                     Print a 4 week collection sheet for this family
                 </button>
+                <a href="{{ route("store.registration.voucher-manager", ['id' => $registration->id ]) }}" class="link">
+                    <div class="link-button link-button-large">
+                        <i class="fa fa-ticket button-icon" aria-hidden="true"></i>Go to voucher manager
+                    </div>
+                </a>
             </div>
         </form>
 


### PR DESCRIPTION

https://trello.com/c/phHQ12sM/1453-move-voucher-manager-button-out-of-child-and-pregnancies-section-v-e

- moved link
- `display: block` allows margin collapse for more consistent vertical spacing