### PR TITLE
Give the cookie warning it's own yield, and move it to the top of the…

### DIFF
--- a/resources/views/store/auth/login.blade.php
+++ b/resources/views/store/auth/login.blade.php
@@ -5,7 +5,9 @@
 @section('hoist-head')
     <!-- specifically to avoid login page timeout -->
     <meta http-equiv="refresh" content="{{ (config('session.lifetime') * 60) - 30 }};url={{ route('store.login') }}" />
+@endsection
 
+@section('cookie-warning')
     <div class="cookie-notice">
         <p>We use cookies to authenticate you so we can ensure that we give you the best experience on our website. For more information please read our <a href="{{ config('arc.links.privacy_policy') }}">Privacy Policy</a>.</p>
         <button class="cookie-agree">Dismiss</button>

--- a/resources/views/store/layouts/service_master.blade.php
+++ b/resources/views/store/layouts/service_master.blade.php
@@ -16,6 +16,7 @@
         @yield('hoist-head')
     </head>
     <body>
+    @yield('cookie-warning')
 
     @include('store.partials.masthead')
 


### PR DESCRIPTION
… body, rather than in the hoist-head, which gets put thin the head (doh!).

https://trello.com/c/ChMl6BOu/1464-extra-body-tag-appearing-in-log-in-page