### PR TITLE
1.8/1471-bug-showing-id-verified-checkbox-when-the-user-shouldt-see-it

### DIFF
--- a/resources/views/store/partials/add_child_form.blade.php
+++ b/resources/views/store/partials/add_child_form.blade.php
@@ -100,7 +100,9 @@
                 // Create the table columns
                 var ageColumn = '<td class="age-col">' + displayYears + ' yr, ' + displayMonths + ' mo</td>';
                 var dobColumn = '<td class="dob-col"><input name="children[' + childKey + '][dob]" type="hidden" value="' + valueDate + '" >' + innerTextDate + '</td>';
-                var idColumn = '<td class="verified-col relative"><input type="checkbox" class="styled-checkbox inline-dob" name="children[' + childKey + '][verified]" id="child' + childKey + '" ' + displayVerified + ' value="' + verifiedValue + '"><label for="child' + childKey + '"><span class="visually-hidden">Toggle ID checked</span></label>' + '</td>';
+                var idColumn = (idCheckedEl.length)
+                    ? '<td class="verified-col relative"><input type="checkbox" class="styled-checkbox inline-dob" name="children[' + childKey + '][verified]" id="child' + childKey + '" ' + displayVerified + ' value="' + verifiedValue + '"><label for="child' + childKey + '"><span class="visually-hidden">Toggle ID checked</span></label>' + '</td>'
+                    : '<td class="verified-col relative"></td>';
                 var removeColumn = '<td class="remove-col"><button type="button" class="remove_date_field"><i class="fa fa-minus" aria-hidden="true"></i></button></td>';
 
                 // add an input


### PR DESCRIPTION
Turns out we were showing a checkbox to people to tick on unseaved/saved kids, even in centres that don't have that power.

Stuck a check in to avoid drawing that box when it's related "id verfied" box is not in the page.

https://trello.com/c/4a1knHbn/1471-bug-showing-id-verified-checkbox-when-the-user-shouldt-see-it