### PR TITLE
1486-bug-fm-users-can-overwrite-verified-registrations-checked-value-…

### DIFF
--- a/app/Http/Controllers/Store/RegistrationController.php
+++ b/app/Http/Controllers/Store/RegistrationController.php
@@ -183,7 +183,7 @@ class RegistrationController extends Controller
         // Grab carers copy for shift)ing without altering family->carers
         $carers = $registration->family->carers->all();
 
-        // Check if er verify, based on the existing registration's context
+        // Check if we verify, based on the existing registration's context
         $verifying = in_array($registration->centre->sponsor->shortcode, config('arc.verifies_children'));
 
         return view('store.edit_registration', array_merge(

--- a/app/Http/Controllers/Store/RegistrationController.php
+++ b/app/Http/Controllers/Store/RegistrationController.php
@@ -140,9 +140,15 @@ class RegistrationController extends Controller
     {
         /** @var User $user */
         $user = Auth::user();
+
+        // Check if we verify, based on the currently logged in user's context
+        // as we have no registration to refer to yet.
+        $verifying = in_array($user->centre->sponsor->shortcode, config('arc.verifies_children'));
+
         $data = [
             "user_name" => $user->name,
             "centre_name" => ($user->centre) ? $user->centre->name : null,
+            "verifying" => $verifying
         ];
         return view('store.create_registration', $data);
     }
@@ -177,6 +183,9 @@ class RegistrationController extends Controller
         // Grab carers copy for shift)ing without altering family->carers
         $carers = $registration->family->carers->all();
 
+        // Check if er verify, based on the existing registration's context
+        $verifying = in_array($registration->centre->sponsor->shortcode, config('arc.verifies_children'));
+
         return view('store.edit_registration', array_merge(
             $data,
             [
@@ -187,6 +196,7 @@ class RegistrationController extends Controller
                 'children' => $registration->family->children,
                 'noticeReasons' => $valuation->getNoticeReasons(),
                 'entitlement' => $valuation->getEntitlement(),
+                'verifying' => $verifying
             ]
         ));
     }

--- a/resources/views/store/create_registration.blade.php
+++ b/resources/views/store/create_registration.blade.php
@@ -60,7 +60,7 @@
                 <p>To add a child or pregnancy, complete the boxes below with their month and year of birth (or due date) in numbers, e.g. '06 2017' for June 2017.
                 </p>
                 </div>
-                @include('store.partials.add_child_form')
+                @include('store.partials.add_child_form', ['verifying' => $verifying])
                 <div class="added">
                     <label for="child_wrapper">You have added:</label>
                     <table>
@@ -68,7 +68,7 @@
                             <tr>
                                 <td class="age-col">Age</td>
                                 <td class="dob-col">Month / Year</td>
-                                @if ( in_array(auth::user()->centre->sponsor->shortcode, config('arc.verifies_children')) )
+                                @if ( $verifying )
                                 <td class="verified-col">ID</td>
                                 @endif
                                 <td class="remove-col"></td>

--- a/resources/views/store/edit_registration.blade.php
+++ b/resources/views/store/edit_registration.blade.php
@@ -138,7 +138,7 @@
                                 {{--
                                 TODO : This is not scalable; if this breaks or has to be extended, look at a better abstraction.
                                 --}}
-                                @if ( $verifying )
+                                @if (in_array($registration->centre->sponsor->shortcode, config('arc.extended_sponsors')))
                                     <li>Primary school to secondary school start - 3 vouchers<br>
                                         <small>(Only if family has a child still under primary school age too)</small>
                                     </li>

--- a/resources/views/store/edit_registration.blade.php
+++ b/resources/views/store/edit_registration.blade.php
@@ -60,14 +60,14 @@
                     <img src="{{ asset('store/assets/pregnancy-light.svg') }}" name="logo">
                     <h2>Children or pregnancy</h2>
                 </div>
-                @include('store.partials.add_child_form')
+                @include('store.partials.add_child_form', ['verifying' => $verifying] )
                 <div>
                     <table>
                         <thead>
                         <tr>
                             <td class="age-col">Age</td>
                             <td class="dob-col">Month / Year</td>
-                            @if ( in_array(auth::user()->centre->sponsor->shortcode, config('arc.verifies_children')) )
+                            @if ( $verifying )
                             <td class="verified-col">ID</td>
                             @endif
                             <td class="remove-col"></td>
@@ -78,7 +78,7 @@
                             <tr>
                                 <td class="age-col">{{ $child->getAgeString() }}</td>
                                 <td class="dob-col">{{ $child->getDobAsString() }}</td>
-                                @if ( in_array(auth::user()->centre->sponsor->shortcode, config('arc.verifies_children')) )
+                                @if ( $verifying )
                                 <td class="verified-col relative"><input type="checkbox" class="styled-checkbox inline-dob" name="children[{{ $child->id }}][verified]" id="child{{ $child->id }}" {{ $child->verified ? "checked" : null }} value="1"><label for="child{{ $child->id }}"><span class="visually-hidden">Toggle ID checked</span></label></td>
                                 @endif
                                 <td class="remove-col">
@@ -138,7 +138,7 @@
                                 {{--
                                 TODO : This is not scalable; if this breaks or has to be extended, look at a better abstraction.
                                 --}}
-                                @if (in_array($registration->centre->sponsor->shortcode, config('arc.extended_sponsors')) )
+                                @if ( $verifying )
                                     <li>Primary school to secondary school start - 3 vouchers<br>
                                         <small>(Only if family has a child still under primary school age too)</small>
                                     </li>

--- a/resources/views/store/partials/add_child_form.blade.php
+++ b/resources/views/store/partials/add_child_form.blade.php
@@ -11,7 +11,7 @@
         <input id="dob-year" name="dob-year" type="number" pattern="[0-9]*" min="0"
                 max="{{ Carbon\Carbon::now()->year }}">
     </div>
-    @if ( in_array(auth::user()->centre->sponsor->shortcode, config('arc.verifies_children')) )
+    @if ( $verifying )
     <div class="dob-input relative">
         <input type="checkbox" class="styled-checkbox" id="dob-verified" name="dob-verified">
         <label for="dob-verified">ID Checked</label>


### PR DESCRIPTION
…unintentionally

Changed it so that verifying checkboxes are dependent on the registration context in edit, and the user's context in create.

https://trello.com/c/Tj5DwCPq/1486-bug-fm-users-can-overwrite-verified-registrations-checked-value-unintentionally