### PR TITLE
1.9/HOTFIX - 1528-if-there-are-no-registrations-we-explode-when-exporting-user-registrations

### DIFF
--- a/app/Http/Controllers/Store/CentreController.php
+++ b/app/Http/Controllers/Store/CentreController.php
@@ -83,6 +83,14 @@ class CentreController extends Controller
 
         $summary = $this->getCentreRegistrationsSummary($centre_ids, $dateFormats, $excludeColumns);
 
+        list($rows, $headers) = $summary;
+
+        if (count($headers) < 1 || count($rows) < 1) {
+            return redirect()
+                ->route('store.dashboard')
+                ->with('error_message', 'No Registrations in that centre.');
+        }
+
         return $this->streamFile(
             $this->writeExcelDoc($summary)
         );


### PR DESCRIPTION
Linked card [https://trello.com/c/z2bSfJC2/1528-hotfix-if-there-are-no-registrations-we-explode-when-exporting-user-registrations-v-e](https://trello.com/c/z2bSfJC2/1528-hotfix-if-there-are-no-registrations-we-explode-when-exporting-user-registrations-v-e)