### PR TITLE
1.9/1535-search-page-success-message-content-may-be-insensitive

### DIFF
--- a/resources/views/store/partials/success.blade.php
+++ b/resources/views/store/partials/success.blade.php
@@ -3,6 +3,6 @@
         <i class="fa fa-check-circle-o" aria-hidden="true"></i>
     </div>
     <p>
-        <span>Success:</span> {{ Session::get('message') }}
+        {{ Session::get('message') }}
     </p>
 </div>


### PR DESCRIPTION
### Trello card :point_right: [https://trello.com/c/2pD6F8w1/1535-bug-search-page-success-message-content-may-be-user-unfriendly](https://trello.com/c/2pD6F8w1/1535-bug-search-page-success-message-content-may-be-user-unfriendly)

![Screenshot from 2020-03-11 10-23-33](https://user-images.githubusercontent.com/29477363/76410145-5e2d8e00-6387-11ea-80f1-4b24e02384e0.png)

![Screenshot from 2020-03-11 10-57-10](https://user-images.githubusercontent.com/29477363/76410153-608fe800-6387-11ea-8808-1eb859f366c6.png)
