### PR TITLE
1.9/display birthday reminders and other notices in voucher managers

### DIFF
--- a/app/Http/Controllers/Store/BundleController.php
+++ b/app/Http/Controllers/Store/BundleController.php
@@ -57,15 +57,6 @@ class BundleController extends Controller
 
         $valuation = $registration->getValuation();
 
-        // We only need the reasons at family level.
-        // TODO: move this to a Valuation if we use this elsewhere.
-        $familyNoticeReasons = array_filter(
-            $valuation->getNoticeReasons(),
-            function ($notice) {
-                return $notice["entity"] == "Family";
-            }
-        );
-
         return view('store.manage_vouchers', array_merge(
             $data,
             [
@@ -78,7 +69,7 @@ class BundleController extends Controller
                 "vouchers" => $sorted_bundle,
                 "vouchers_amount" => count($bundle),
                 "entitlement" => $valuation->getEntitlement(),
-                "noticeReasons" => $familyNoticeReasons
+                "noticeReasons" => $valuation->getNoticeReasons()
             ]
         ));
     }

--- a/app/Services/VoucherEvaluator/Evaluations/FamilyHasUnverifiedChildren.php
+++ b/app/Services/VoucherEvaluator/Evaluations/FamilyHasUnverifiedChildren.php
@@ -7,7 +7,7 @@ use Carbon\Carbon;
 
 class FamilyHasUnverifiedChildren extends BaseFamilyEvaluation
 {
-    public $reason = 'has children needing ID';
+    public $reason = 'has one or more children that you haven\'t checked ID for yet';
     private $specification;
 
     /**

--- a/resources/views/store/partials/notice_box.blade.php
+++ b/resources/views/store/partials/notice_box.blade.php
@@ -5,7 +5,10 @@
     <div id="family-warning">
         @foreach( $noticeReasons as $notices )
         <p class="v-spaced">
-            {{ $notices['count'] }} {{ str_plural($notices['entity'], $notices['count']) }} currently {{$notices['reason'] }}
+            {{ $notices['count'] === 1 ? 'A' : $notices['count'] }} {{ str_plural(strtolower($notices['entity']),
+            $notices['count'])
+            }} currently
+            {{$notices['reason'] }}
         </p>
         @endforeach
     </div>

--- a/tests/Feature/Store/VoucherManagerTest.php
+++ b/tests/Feature/Store/VoucherManagerTest.php
@@ -147,13 +147,9 @@ class VoucherManagerTest extends StoreTestCase
         $notices = $registration->getValuation()->getNoticeReasons();
         $this->assertGreaterThan(0, count($notices));
 
-        // We can see only family warnings
+        // We can see the notice reason
         foreach ($notices as $notice) {
-            if ($notice["entity"] == "Family") {
-                $this->see($notice["reason"]);
-            } else {
-                $this->dontSee($notice["reason"]);
-            }
+            $this->see($notice["reason"]);
         }
     }
 

--- a/tests/Unit/Services/VoucherEvaluator/VoucherEvaluatorTest.php
+++ b/tests/Unit/Services/VoucherEvaluator/VoucherEvaluatorTest.php
@@ -25,7 +25,7 @@ class VoucherEvaluatorTest extends TestCase
         'ChildIsAlmostTwelve' => ['reason' => 'Child|almost 12 years old'],
         'ChildIsSchoolAge' => ['reason' => 'Child|school age'],
         'ChildIsSecondarySchoolAge' => ['reason' => 'Child|secondary school age'],
-        'FamilyHasUnverifiedChildren' => ['reason' => 'Family|has children needing ID']
+        'FamilyHasUnverifiedChildren' => ['reason' => 'Family|has one or more children that you haven\'t checked ID for yet']
     ];
 
     // This has a | in the reason field because we want to carry the entity with it.


### PR DESCRIPTION
### Trello card :point_right: [https://trello.com/c/6nWGfbmR/1509-southwark-seeing-is-id-seen-box-ticked-in-a-rapid-way-during-voucher-processing-ee-vv](https://trello.com/c/6nWGfbmR/1509-southwark-seeing-is-id-seen-box-ticked-in-a-rapid-way-during-voucher-processing-ee-vv) 
- @jermyk has identified this bug while testing the card
- copy of one of the notices also changes following advice on this :point_up: card