### PR TITLE
1.9/1541-firefox-date-selector-partially-hides-month-year

### DIFF
--- a/public/store/css/main.css
+++ b/public/store/css/main.css
@@ -86,6 +86,10 @@ input[type=number]::-webkit-outer-spin-button {
 	margin: 0;
 }
 
+input[type=number] {
+    -moz-appearance:textfield;
+}
+
 input[type="radio"],
 .styled-checkbox,
 .inline-dob {


### PR DESCRIPTION
### Trello card 👉 [https://trello.com/c/y9XIxYGa/1541-firefox-date-selector-partially-hides-month-year](https://trello.com/c/y9XIxYGa/1541-firefox-date-selector-partially-hides-month-year)