### PR TITLE
Disable the notifications that children are under school ages, becuas…

### DIFF
--- a/app/Services/VoucherEvaluator/EvaluatorFactory.php
+++ b/app/Services/VoucherEvaluator/EvaluatorFactory.php
@@ -116,12 +116,16 @@ class EvaluatorFactory
                 'notices' => [
                     // warn if we're almost 1yo
                     new ChildIsAlmostOne($offsetDate),
-                    // or if under school age
-                    new ChildIsUnderSchoolAge($offsetDate),
+
+                    // ... or if under school age; turns out we don't need this here!
+                    # new ChildIsUnderSchoolAge($offsetDate),
+
                     // ... or if almost primary school age
                     new ChildIsAlmostSchoolAge($offsetDate),
-                    // ... or if actually primary school age
-                    new ChildIsSchoolAge($offsetDate),
+
+                    // ... or if actually primary school age; turns out we don't need this here!
+                    # new ChildIsSchoolAge($offsetDate)
+
                     // ... or if almost secondary school age
                     new ChildIsAlmostSecondarySchoolAge($offsetDate),
                 ],

--- a/tests/Unit/Services/VoucherEvaluator/VoucherEvaluatorTest.php
+++ b/tests/Unit/Services/VoucherEvaluator/VoucherEvaluatorTest.php
@@ -292,8 +292,8 @@ class VoucherEvaluatorTest extends TestCase
         $evaluation = $evaluator->evaluate($child);
         $notices = $evaluation["notices"];
 
-        // Check there's two
-        $this->assertEquals(2, count($notices));
+        // Check there's one
+        $this->assertEquals(1, count($notices));
 
         // Check the correct credit type is applied.
         $this->assertNotContains(self::NOTICE_TYPES['ChildIsAlmostOne'], $notices);


### PR DESCRIPTION
…e they're not useful.

https://trello.com/c/lmfCEnBC/1548-under-school-age-and-id-reminders-display-intermittently