### PR TITLE
Add delivery for some dispatched and/or bundled vuochers

### DIFF
--- a/database/seeds/BundleSeeder.php
+++ b/database/seeds/BundleSeeder.php
@@ -59,7 +59,7 @@ class BundleSeeder extends Seeder
         /** @var Bundle $bundle */
         $bundle = $registration->currentBundle();
 
-        // Create three random vouchers and transition to printed, then bundle
+        // Create three random vouchers and transition to printed, then deliver and bundle.
         /** @var Collection $vs */
         $vs1 = factory(Voucher::class, 'requested', 3)
             ->create()
@@ -69,6 +69,16 @@ class BundleSeeder extends Seeder
                 $v->applyTransition('print');
                 $v->applyTransition('dispatch');
             });
+
+        // Generate a corresponding delivery
+        $delivery = factory(App\Delivery::class)->create([
+            // Using the reg centre id but it won't match with voucher sponsor since they are random
+            'centre_id' => $registration->centre->id,
+            'dispatched_at' => Carbon::now(),
+            // These are random and will not be a proper range, but should be identifiable with this.
+            'range' => $vs1[0]->code . '-' . $vs1[2]->code,
+        ]);
+        $delivery->vouchers()->saveMany($vs1);
 
         // Ask bundle to add these vouchers.
         $bundle->addVouchers($vs1->pluck('code')->toArray());
@@ -101,7 +111,7 @@ class BundleSeeder extends Seeder
         /** @var Bundle $bundle */
         $bundle = $registration->currentBundle();
 
-        // Create three random vouchers and transition to dispatched, then bundle
+        // Create three random vouchers and transition to dispatched, deliver then bundle
         /** @var Collection $vs */
         $vs1 = factory(Voucher::class, 'requested', 3)
             ->create()
@@ -110,6 +120,16 @@ class BundleSeeder extends Seeder
                 $v->applyTransition('print');
                 $v->applyTransition('dispatch');
             });
+
+        // Generate a corresponding delivery
+        $delivery = factory(App\Delivery::class)->create([
+            // Using the reg centre id but it won't match with voucher sponsor since they are random
+            'centre_id' => $registration->centre->id,
+            'dispatched_at' => Carbon::now(),
+            // These are random and will not be a proper range, but should be identifiable with this.
+            'range' => $vs1[0]->code . '-' . $vs1[2]->code,
+        ]);
+        $delivery->vouchers()->saveMany($vs1);
 
         // Ask bundle to add these vouchers.
         $bundle->addVouchers($vs1->pluck('code')->toArray());


### PR DESCRIPTION
https://trello.com/c/vdRoctaq/1585-alter-seeds-to-include-delivery-for-vouchers-that-are-transitioned-to-dispatched-and-created-after-arcfirstdeliverydate

- Vouchers in currentstate dispatched should have a delivery opr have been created before the first delivery date