### PR TITLE
1.10/1564 remove printed and ordered

### DIFF
--- a/app/Console/Commands/CreateMasterVoucherLogReport.php
+++ b/app/Console/Commands/CreateMasterVoucherLogReport.php
@@ -57,7 +57,6 @@ class CreateMasterVoucherLogReport extends Command
     private $headers = [
         'Voucher Number',
         'Voucher Area',
-        'Date Printed',
         'Date Distributed',
         'Distributed to Centre',
         'Distributed to Area',
@@ -88,10 +87,9 @@ class CreateMasterVoucherLogReport extends Command
 SELECT
   vouchers.code AS 'Voucher Number',
   voucher_sponsor.name AS 'Voucher Area',
-  (select created_at from voucher_states where vouchers.id = voucher_id and `to` = 'printed' order by id desc limit 1) AS 'Date Printed',
   deliveries.dispatched_at as 'Date Distributed',
   delivery_centres.name AS 'Distributed to Centre',
-  delivery_areas.name AS 'Distributed to Area',      
+  delivery_areas.name AS 'Distributed to Area',
   CASE
       WHEN (disbursed_at is null) AND (pri_carer_name is not null) THEN 'True'
       WHEN (disbursed_at is not null) AND (pri_carer_name is not null) THEN 'False'
@@ -108,7 +106,7 @@ SELECT
   (select min(voucher_states.created_at)
     FROM voucher_states
     WHERE voucher_states.`to` = 'payment_pending'
-    and vouchers.id = voucher_id 
+    and vouchers.id = voucher_id
     group by voucher_id
     limit 1) AS 'Date Received for Reimbursement',
   (select created_at from voucher_states where vouchers.id = voucher_id and `to` = 'reimbursed' order by id desc limit 1) AS 'Reimbursed Date',

--- a/app/Voucher.php
+++ b/app/Voucher.php
@@ -248,57 +248,57 @@ class Voucher extends Model
                 return DB::select(
                     "
                     SELECT
-                        t1.*, 
+                        t1.*,
                         v1.code as intitial_code,
                         v2.code as final_code
                     FROM (
-                        
+
                         SELECT
                             @start := if(end - @previous = 1, @start, end) as start,
                             @initial_id := if(end - @previous = 1, @initial_id, id) as initial_id,
                             @previous := end as end,
                             id as final_id
                         FROM (
-                        
+
                             SELECT id, cast(replace(code, '{$shortcode}', '') as signed) as end
                             FROM vouchers
                             WHERE code REGEXP '^{$shortcode}[0-9]+\$'
                               AND currentstate = 'dispatched'
                             ORDER BY end
-                        
+
                         ) as t5
-                    
+
                     ) AS t1
                         INNER JOIN (
-                    
+
                             SELECT start, max(end) as final
                             FROM (
-                    
+
                                  SELECT
                                      @start := if(end - @previous = 1, @start, end) as start,
                                      @initial_id := if(end - @previous = 1, @initial_id, id) as initial_id,
                                      @previous := end as end,
                                      id
                                  FROM (
-                                     
+
                                     SELECT id, cast(replace(code, '{$shortcode}', '') as signed) as end
                                     FROM vouchers
                                     WHERE code REGEXP '^{$shortcode}[0-9]+\$'
                                       AND currentstate = 'dispatched'
                                     ORDER BY end
-                    
+
                                  ) as t4
-                    
+
                             ) as t3
                             GROUP BY start
-                    
+
                         ) as t2
                         ON t1.start = t2.start
                           AND t1.end = t2.final
-                    
+
                     LEFT JOIN vouchers as v1
                         ON initial_id = v1.id
-                    
+
                     LEFT JOIN vouchers as v2
                         ON final_id = v2.id
                     "
@@ -340,7 +340,7 @@ class Voucher extends Model
                     "
                     SELECT
                         # Resolves the sub-queries operation to a table of ranges
-                        t1.*, 
+                        t1.*,
                         v1.code as intitial_code,
                         v2.code as final_code
                     FROM (
@@ -351,16 +351,16 @@ class Voucher extends Model
                             @previous := end as end,
                             id as final_id
                         FROM (
-                            # sub-query that gets the vouchers in a state we want under a specific shortcode. 
+                            # sub-query that gets the vouchers in a state we want under a specific shortcode.
                             SELECT id, cast(replace(code, '{$shortcode}', '') as signed) as end
                             FROM vouchers
                             WHERE code REGEXP '^{$shortcode}[0-9]+\$'
                               AND currentstate = 'printed'
                               AND delivery_id is null
                             ORDER BY end
-                        
+
                         ) as t5
-                    
+
                     ) AS t1
                         INNER JOIN (
                             # Bit of a self join going on in this one to find the end values.
@@ -374,24 +374,24 @@ class Voucher extends Model
                                      id
                                  FROM (
                                       SELECT id, cast(replace(code, '{$shortcode}', '') as signed) as end
-                                      FROM vouchers 
+                                      FROM vouchers
                                       WHERE code REGEXP '^{$shortcode}[0-9]+\$'
                                         AND currentstate = 'printed'
                                         AND delivery_id is null
                                       ORDER BY end
-                    
+
                                  ) as t4
-                    
+
                             ) as t3
                             GROUP BY start
-                    
+
                         ) as t2
                         ON t1.start = t2.start
                           AND t1.end = t2.final
-                    
+
                     LEFT JOIN vouchers as v1
                         ON initial_id = v1.id
-                    
+
                     LEFT JOIN vouchers as v2
                         ON final_id = v2.id
                     "

--- a/config/state-machine.php
+++ b/config/state-machine.php
@@ -10,8 +10,6 @@ return [
 
         // list of all possible states
         'states' => [
-            'requested',
-            'ordered',
             'printed',
             'dispatched',
             'recorded', // submitted to shortlist
@@ -25,14 +23,6 @@ return [
         // list of all possible transitions
         'transitions' => [
 
-            'order' => [
-                'from' => ['requested'],
-                'to' => 'ordered',
-            ],
-            'print' => [
-                'from' =>  ['ordered'],
-                'to' => 'printed',
-            ],
             'dispatch' => [
                 'from' => ['printed'],
                 'to' => 'dispatched',

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -241,14 +241,15 @@ $factory->define(App\Voucher::class, function (Faker\Generator $faker) {
 });
 
 /**
- * Voucher with currentstate requested.
+ * Voucher with currentstate printed.
  */
-$factory->defineAs(App\Voucher::class, 'requested', function ($faker) use ($factory) {
+$factory->defineAs(App\Voucher::class, 'printed', function ($faker) use ($factory) {
 
+    // As our starting state, we do not require a `voucher_state` to be generated.
     $voucher = $factory->raw(App\Voucher::class);
 
     return array_merge($voucher, [
-        'currentstate' => 'requested',
+        'currentstate' => 'printed',
     ]);
 });
 
@@ -258,18 +259,9 @@ $factory->defineAs(App\Voucher::class, 'requested', function ($faker) use ($fact
 $factory->defineAs(App\Voucher::class, 'dispatched', function ($faker) use ($factory) {
     $voucher = $factory->raw(App\Voucher::class);
 
-    // Todo create the voucher_states on the road to dispatched.
+    // Dispatched is the first state, so we can go with default values here.
     factory(App\VoucherState::class)->create();
-    factory(App\VoucherState::class)->create([
-        'transition' => 'print',
-        'from' => 'ordered',
-        'to' => 'printed',
-    ]);
-    factory(App\VoucherState::class)->create([
-        'transition' => 'dispatch',
-        'from' => 'printed',
-        'to' => 'dispatched',
-    ]);
+
     return array_merge($voucher, [
         'currentstate' => 'dispatched',
     ]);
@@ -277,16 +269,15 @@ $factory->defineAs(App\Voucher::class, 'dispatched', function ($faker) use ($fac
 
 $factory->define(App\VoucherState::class, function (Faker\Generator $faker) {
 
-    // Factory adds initial values - overwrite when we create.
-    // There will be a batter way to seed states - but for now
-    // just need a way to force one.
+    // Factory adds initial values for first possible state (dispatched)
+    // Overwrite when we create - other states.
     return [
-        'transition' => 'order',
-        'from' => 'requested',
+        'transition' => 'dispatch',
+        'from' => 'printed',
         'user_id' => 1,
         'voucher_id' => 1,
-        'to' => 'ordered',
-        // Not sure what source refers to.
+        'to' => 'dispatched',
+        // Required by the state package we are using, but we don't use this field
         'source' => 'factory',
     ];
 });

--- a/database/migrations/2020_05_21_094708_remove_ordered_printed_from_voucher_states_table.php
+++ b/database/migrations/2020_05_21_094708_remove_ordered_printed_from_voucher_states_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class RemoveOrderedPrintedFromVoucherStatesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('voucher_states', function (Blueprint $table) {
+            // I guess nice to have a record of how many rows were deleted?
+            $number_to_delete = App\VoucherState::whereIn('to', ['ordered', 'printed'])->count();
+
+            App\VoucherState::whereIn('to', ['ordered', 'printed'])->delete();
+            Log::info($number_to_delete . ' printed and ordered voucher_states records deleted on migration.');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('voucher_states', function (Blueprint $table) {
+            // We have destroyed the records. If we need them back, grab from pre-deploy sql dump.
+            // We could alternatively reconstruct them based on the voucher created_at.
+            // This would include some moving around of data since at least 185000 vouchers
+            // were missing these states - and we need ids to be same order as timestamps.
+        });
+    }
+}

--- a/database/seeds/BundleSeeder.php
+++ b/database/seeds/BundleSeeder.php
@@ -59,14 +59,11 @@ class BundleSeeder extends Seeder
         /** @var Bundle $bundle */
         $bundle = $registration->currentBundle();
 
-        // Create three random vouchers and transition to printed, then deliver and bundle.
+        // Create three random vouchers and transition to dispatched, then deliver and bundle.
         /** @var Collection $vs */
-        $vs1 = factory(Voucher::class, 'requested', 3)
+        $vs1 = factory(Voucher::class, 'printed', 3)
             ->create()
             ->each(function (Voucher $v) {
-                $v->applyTransition('order');
-
-                $v->applyTransition('print');
                 $v->applyTransition('dispatch');
             });
 
@@ -111,13 +108,11 @@ class BundleSeeder extends Seeder
         /** @var Bundle $bundle */
         $bundle = $registration->currentBundle();
 
-        // Create three random vouchers and transition to dispatched, deliver then bundle
+        // Create three random vouchers and transition to dispatched, then deliver then bundle
         /** @var Collection $vs */
-        $vs1 = factory(Voucher::class, 'requested', 3)
+        $vs1 = factory(Voucher::class, 'printed', 3)
             ->create()
             ->each(function (Voucher $v) {
-                $v->applyTransition('order');
-                $v->applyTransition('print');
                 $v->applyTransition('dispatch');
             });
 

--- a/database/seeds/DeliverySeeder.php
+++ b/database/seeds/DeliverySeeder.php
@@ -51,15 +51,13 @@ class DeliverySeeder extends Seeder
                     $shortcode . "01" . $key . "050"
                 );
                 // Turn those into vouchers
-                $vs = factory(Voucher::class, 'requested', count($codes))
+                $vs = factory(Voucher::class, 'printed', count($codes))
                     ->create([
                         'code' => function () use (&$codes) {
                             return array_pop($codes);
                         },
                     ])
                     ->each(function (Voucher $v) {
-                        $v->applyTransition('order');
-                        $v->applyTransition('print');
                         $v->applyTransition('dispatch');
                     });
                 $delivery->vouchers()->saveMany($vs);

--- a/database/seeds/TestActiveUsersSeeder.php
+++ b/database/seeds/TestActiveUsersSeeder.php
@@ -111,13 +111,11 @@ class TestActiveUsersSeeder extends Seeder
                 /** @var Bundle $bundle */
                 $bundle = $reg->currentBundle();
 
-                // Create three random vouchers and transition to printed, then bundle
+                // Create three random vouchers and transition to dispatched, then bundle
                 /** @var Collection $vs */
-                $vs = factory(Voucher::class, 'requested', 3)
+                $vs = factory(Voucher::class, 'printed', 3)
                     ->create()
                     ->each(function (Voucher $v) {
-                        $v->applyTransition('order');
-                        $v->applyTransition('print');
                         $v->applyTransition('dispatch');
                     });
 

--- a/database/seeds/VouchersSeeder.php
+++ b/database/seeds/VouchersSeeder.php
@@ -22,17 +22,16 @@ class VouchersSeeder extends Seeder
         // Create RVNT one as id 1 our trader will be affiliated with this.
         $rvp = App\Sponsor::where('shortcode', 'RVNT')->first();
 
-        // Only requested state works with seeder for now.
         // Only 40 for now or we will get 9 digits.
         // These vouchers dispatched before we added delivery to system.
         // They can be collected even though they do not have a delivery_id.
         $timestamp_pre_delivery = Carbon\Carbon::parse(config('arc.first_delivery_date'))->subMonth(1);
-        $rvp_vouchers = factory(App\Voucher::class, 'requested', 40)->create([
+        $rvp_vouchers = factory(App\Voucher::class, 'printed', 40)->create([
             'created_at' => $timestamp_pre_delivery,
         ]);
 
         // Make some random vouchers.
-        factory(App\Voucher::class, 'requested', 50)->create();
+        factory(App\Voucher::class, 'printed', 50)->create();
 
         $size = sizeOf($rvp_vouchers);
         // Assign the codes that match the paper.
@@ -41,12 +40,6 @@ class VouchersSeeder extends Seeder
             $rvp_vouchers[$k]->code = 'RVNT123455'.$i;
             $rvp_vouchers[$k]->sponsor_id = $rvp->id;
             $rvp_vouchers[$k]->save();
-
-            if ($rvp_vouchers[$k]->id < 32) {
-                //Progress these to printed.
-                $rvp_vouchers[$k]->applyTransition('order');
-                $rvp_vouchers[$k]->applyTransition('print');
-            }
 
             if ($rvp_vouchers[$k]->id < 22) {
                 //Progress these to dispatched.
@@ -84,13 +77,11 @@ class VouchersSeeder extends Seeder
         }
 
         // 4 digit printed vouchers for trial.
-        $rvnt4 = factory(App\Voucher::class, 'requested', 100)->create();
+        $rvnt4 = factory(App\Voucher::class, 'printed', 100)->create();
         foreach ($rvnt4 as $k => $v) {
             $v->code = 'RVNT' . str_pad($k, 4, '0', STR_PAD_LEFT);
             $v->sponsor_id = $rvp->id;
-            // Progress to printed.
-            $v->applyTransition('order');
-            $v->applyTransition('print');
+            // Progress to dispatched.
             $v->applyTransition('dispatch');
         }
 

--- a/routes/service.php
+++ b/routes/service.php
@@ -43,7 +43,7 @@ Route::group(['middleware' => 'auth:admin'], function () {
         'as' => 'admin.vouchers.void',
         'uses' => 'Admin\VouchersController@void',
     ]);
-    // ...transition to printed
+    // ...store batch of printed
     Route::post('vouchers', [
         'as' => 'admin.vouchers.storebatch',
         'uses' => 'Admin\VouchersController@storeBatch',

--- a/tests/Feature/Store/PaymentPageTest.php
+++ b/tests/Feature/Store/PaymentPageTest.php
@@ -22,15 +22,13 @@ class PaymentPageTest extends StoreTestCase
         parent::setUp();
 
         // Create a voucher and a trader with some info
-        $this->voucher = factory(Voucher::class, 'requested')->create();
+        $this->voucher = factory(Voucher::class, 'printed')->create();
         $trader = factory(Trader::class, 'withnullable')->create();
         $this->voucher->code = 'TEST12345';
         $this->voucher->trader_id = $trader->id;
         $this->voucher->save();
 
         // Transition to PaymentPending
-        $this->voucher->applyTransition('order');
-        $this->voucher->applyTransition('print');
         $this->voucher->applyTransition('dispatch');
         $this->voucher->applyTransition('collect');
         $this->voucher->applyTransition('confirm');

--- a/tests/Feature/Store/VoucherManagerTest.php
+++ b/tests/Feature/Store/VoucherManagerTest.php
@@ -65,11 +65,9 @@ class VoucherManagerTest extends StoreTestCase
         Auth::login($this->fmUser);
 
         foreach ($this->testCodes as $testCode) {
-            $voucher = factory(Voucher::class, 'requested')->create([
+            $voucher = factory(Voucher::class, 'printed')->create([
                 'code' => $testCode
             ]);
-            $voucher->applyTransition('order');
-            $voucher->applyTransition('print');
             $voucher->applyTransition('dispatch');
         }
 

--- a/tests/Unit/Controllers/Api/ApiVoucherControllerTest.php
+++ b/tests/Unit/Controllers/Api/ApiVoucherControllerTest.php
@@ -34,12 +34,8 @@ class ApiVoucherControllerTest extends TestCase
 
         Auth::login($this->user);
 
-        // Create some vouchers at dispatched state
-        $this->vouchers = factory(Voucher::class, 'requested', 10)->create();
-        $this->vouchers->each(function ($voucher) {
-            $voucher->applyTransition('order');
-            $voucher->applyTransition('print');
-        });
+        // Create some vouchers at printed state
+        $this->vouchers = factory(Voucher::class, 'printed', 10)->create();
     }
 
     /**

--- a/tests/Unit/Controllers/Api/TraderControllerTest.php
+++ b/tests/Unit/Controllers/Api/TraderControllerTest.php
@@ -24,14 +24,12 @@ class TraderControllerTest extends TestCase
     {
         parent::setUp();
         $this->traders = factory(Trader::class, 2)->create();
-        $this->vouchers = factory(Voucher::class, 'requested', 10)->create();
+        $this->vouchers = factory(Voucher::class, 'printed', 10)->create();
         $this->user = factory(User::class)->create();
 
         // Set up voucher states.
         Auth::login($this->user);
         foreach ($this->vouchers as $v) {
-            $v->applyTransition('order');
-            $v->applyTransition('print');
             $v->applyTransition('dispatch');
             $v->trader_id = 1;
             $v->applyTransition('collect');

--- a/tests/Unit/Controllers/Service/Admin/DeliveryControllerMysqlTest.php
+++ b/tests/Unit/Controllers/Service/Admin/DeliveryControllerMysqlTest.php
@@ -83,12 +83,10 @@ class DeliveryControllerMysqlTest extends StoreTestCase
         Auth::login($this->user);
 
         foreach ($this->rangeCodes as $rangeCode) {
-            $voucher = factory(Voucher::class, 'requested')->create([
+            $voucher = factory(Voucher::class, 'printed')->create([
                 'code' => $rangeCode,
                 'sponsor_id' => $this->sponsor->id,
             ]);
-            $voucher->applyTransition('order');
-            $voucher->applyTransition('print');
         }
 
         Auth::logout();
@@ -125,7 +123,7 @@ class DeliveryControllerMysqlTest extends StoreTestCase
             ->seePageIs($successRoute)
             ->see($msg)
         ;
-        
+
         // fetch those back.
         $vouchers = Voucher::where('currentstate', 'dispatched')
             ->with('delivery')

--- a/tests/Unit/Controllers/Service/Admin/VoucherControllerMysqlTest.php
+++ b/tests/Unit/Controllers/Service/Admin/VoucherControllerMysqlTest.php
@@ -75,12 +75,10 @@ class VoucherControllerMysqlTest extends StoreTestCase
         Auth::login($this->user);
 
         foreach ($this->rangeCodes as $rangeCode) {
-            $voucher = factory(Voucher::class, 'requested')->create([
+            $voucher = factory(Voucher::class, 'printed')->create([
                 'code' => $rangeCode,
                 'sponsor_id' => $this->sponsor->id,
             ]);
-            $voucher->applyTransition('order');
-            $voucher->applyTransition('print');
             $voucher->applyTransition('dispatch');
         }
 

--- a/tests/Unit/Controllers/Store/BundleControllerTest.php
+++ b/tests/Unit/Controllers/Store/BundleControllerTest.php
@@ -53,11 +53,9 @@ class BundleControllerTest extends StoreTestCase
         Auth::login($this->centreUser);
 
         foreach ($this->testCodes as $testCode) {
-            $voucher = factory(Voucher::class, 'requested')->create([
+            $voucher = factory(Voucher::class, 'printed')->create([
                 'code' => $testCode
             ]);
-            $voucher->applyTransition('order');
-            $voucher->applyTransition('print');
             $voucher->applyTransition('dispatch');
         }
 
@@ -251,11 +249,9 @@ class BundleControllerTest extends StoreTestCase
         // Create the vouchers for the range;
         Auth::login($this->centreUser);
         foreach ($bigRange as $testCode) {
-            $voucher = factory(Voucher::class, 'requested')->create([
+            $voucher = factory(Voucher::class, 'printed')->create([
                 'code' => $testCode
             ]);
-            $voucher->applyTransition('order');
-            $voucher->applyTransition('print');
             $voucher->applyTransition('dispatch');
         }
         Auth::logout();
@@ -330,11 +326,9 @@ class BundleControllerTest extends StoreTestCase
             'TST0123457'
         ];
         foreach ($testCodes as $testCode) {
-            $voucher = factory(Voucher::class, 'requested')->create([
+            $voucher = factory(Voucher::class, 'printed')->create([
                 'code' => $testCode
             ]);
-            $voucher->applyTransition('order');
-            $voucher->applyTransition('print');
             $voucher->applyTransition('dispatch');
             $voucher->bundle()->associate($currentBundle)->save();
         }
@@ -384,11 +378,9 @@ class BundleControllerTest extends StoreTestCase
             'TST0123457'
         ];
         foreach ($testCodes as $testCode) {
-            $voucher = factory(Voucher::class, 'requested')->create([
+            $voucher = factory(Voucher::class, 'printed')->create([
                 'code' => $testCode
             ]);
-            $voucher->applyTransition('order');
-            $voucher->applyTransition('print');
             $voucher->applyTransition('dispatch');
             $voucher->bundle()->associate($currentBundle)->save();
         }

--- a/tests/Unit/FormRequests/AdminUpdateVoucherRequestTest.php
+++ b/tests/Unit/FormRequests/AdminUpdateVoucherRequestTest.php
@@ -48,14 +48,14 @@ class AdminUpdateVoucherRequestTest extends StoreTestCase
 
         // Batch make those vouchers
         foreach ($rangeCodes as $rangeCode) {
-            factory(Voucher::class, 'requested')->create([
+            factory(Voucher::class, 'printed')->create([
                 'code' => $rangeCode,
                 'sponsor_id' => $sponsor->id,
             ]);
         }
 
         // Make the error voucher
-        factory(Voucher::class, 'requested')->create([
+        factory(Voucher::class, 'printed')->create([
             'code' => 'ERR0105',
             'sponsor_id' => $err_sponsor->id,
         ]);

--- a/tests/Unit/Listeners/SendVoucherHistoryEmailTest.php
+++ b/tests/Unit/Listeners/SendVoucherHistoryEmailTest.php
@@ -30,7 +30,7 @@ class SendVoucherHistoryEmailTest extends TestCase
     {
         parent::setUp();
         $this->traders = factory(Trader::class, 2)->create();
-        $this->vouchers = factory(Voucher::class, 'requested', 10)->create();
+        $this->vouchers = factory(Voucher::class, 'printed', 10)->create();
         $this->user = factory(User::class)->create();
 
         // Add market to trader[1];
@@ -45,8 +45,6 @@ class SendVoucherHistoryEmailTest extends TestCase
         Auth::login($this->user);
 
         foreach ($this->vouchers as $v) {
-            $v->applyTransition('order');
-            $v->applyTransition('print');
             $v->applyTransition('dispatch');
             $v->trader_id = 1;
             $v->applyTransition('collect');

--- a/tests/Unit/Listeners/SendVoucherPaymentRequestEmailTest.php
+++ b/tests/Unit/Listeners/SendVoucherPaymentRequestEmailTest.php
@@ -32,7 +32,7 @@ class SendVoucherPaymentRequestEmailTest extends TestCase
     {
         parent::setUp();
         $this->traders = factory(Trader::class, 2)->create();
-        $this->vouchers = factory(Voucher::class, 'requested', 10)->create();
+        $this->vouchers = factory(Voucher::class, 'printed', 10)->create();
         $this->user = factory(User::class)->create();
 
         // Add market to trader[1];
@@ -50,8 +50,6 @@ class SendVoucherPaymentRequestEmailTest extends TestCase
         $this->stateToken = factory(StateToken::class)->create();
 
         foreach ($this->vouchers as $v) {
-            $v->applyTransition('order');
-            $v->applyTransition('print');
             $v->applyTransition('dispatch');
             $v->trader_id = 1;
             $v->applyTransition('collect');

--- a/tests/Unit/Listeners/StateHistoryManagerTest.php
+++ b/tests/Unit/Listeners/StateHistoryManagerTest.php
@@ -32,15 +32,9 @@ class StateHistoryManagerTest extends TestCase
     public function testStateIsUpdatedAsExpected()
     {
         Auth::login($this->adminUser);
+
         // create a voucher as printed
-
-        $v = factory(Voucher::class, 'requested')->create();
-        $v->applyTransition('order');
-        $v->applyTransition('print');
-
-        $state = $v->history()->get(null)->last();
-        $this->assertEquals(Auth::user()->id, $state->user_id);
-        $this->assertEquals(class_basename(Auth::user()), $state->user_type);
+        $v = factory(Voucher::class, 'printed')->create();
 
         Auth::login($this->centreUser);
         $v->applyTransition('dispatch');

--- a/tests/Unit/Models/BundleModelTest.php
+++ b/tests/Unit/Models/BundleModelTest.php
@@ -52,11 +52,9 @@ class BundleModelTest extends TestCase
         $carer = factory(Carer::class)->create(['name'=>'Bob','family_id'=>$family->id]);
 
         //create three vouchers and transition to collected.
-        $vs = factory('App\Voucher', 'requested', 3)
+        $vs = factory('App\Voucher', 'printed', 3)
             ->create()
             ->each(function ($v) {
-                $v->applyTransition('order');
-                $v->applyTransition('print');
                 $v->applyTransition('dispatch');
                 $v->applyTransition('collect');
                 $v->bundle()->associate($this->bundle);
@@ -84,12 +82,10 @@ class BundleModelTest extends TestCase
         $user = factory('App\CentreUser')->create();
         Auth::login($user);
 
-        // Create three vouchers and transition to printed.
-        $vs = factory('App\Voucher', 'requested', 3)
+        // Create three vouchers.
+        $vs = factory('App\Voucher', 'printed', 3)
             ->create()
             ->each(function ($v) {
-                $v->applyTransition('order');
-                $v->applyTransition('print');
                 $v->bundle()->associate($this->bundle);
                 $v->save();
             });
@@ -135,11 +131,9 @@ class BundleModelTest extends TestCase
         $disbursedBundle = factory(Bundle::class)->create();
 
         // Make some vouchers and add those to it.
-        $vs = factory('App\Voucher', 'requested', 3)
+        $vs = factory('App\Voucher', 'printed', 3)
             ->create()
             ->each(function ($v) use ($disbursedBundle) {
-                $v->applyTransition('order');
-                $v->applyTransition('print');
                 $v->applyTransition('dispatch');
                 $v->bundle()->associate($disbursedBundle);
                 $v->save();

--- a/tests/Unit/Models/DeliveryModelTest.php
+++ b/tests/Unit/Models/DeliveryModelTest.php
@@ -38,11 +38,9 @@ class DeliveryModelTest extends TestCase
         $centre = factory('App\Centre')->create();
 
         // create three vouchers and transition to collected.
-        $vs = factory('App\Voucher', 'requested', 3)
+        $vs = factory('App\Voucher', 'printed', 3)
             ->create()
             ->each(function ($v) {
-                $v->applyTransition('order');
-                $v->applyTransition('print');
                 $v->applyTransition('dispatch');
                 $v->delivery()->associate($this->delivery);
                 $v->save();
@@ -64,12 +62,10 @@ class DeliveryModelTest extends TestCase
     /** @test */
     public function testDeliveryCanHaveManyVouchers()
     {
-        // Create three vouchers and transition to printed.
-        $vs = factory('App\Voucher', 'requested', 3)
+        // Create three vouchers and transition to dipatched.
+        $vs = factory('App\Voucher', 'printed', 3)
             ->create()
             ->each(function ($v) {
-                $v->applyTransition('order');
-                $v->applyTransition('print');
                 $v->applyTransition('dispatch');
                 $v->delivery()->associate($this->delivery);
                 $v->save();

--- a/tests/Unit/Models/TraderModelTest.php
+++ b/tests/Unit/Models/TraderModelTest.php
@@ -58,7 +58,7 @@ class TraderModelTest extends TestCase
 
     public function testTraderHasConfirmedVouchers()
     {
-        $vouchers = factory(Voucher::class, 'requested', 3)->create([
+        $vouchers = factory(Voucher::class, 'printed', 3)->create([
             'trader_id' => $this->trader->id,
         ]);
 
@@ -67,8 +67,6 @@ class TraderModelTest extends TestCase
         Auth::login($user);
 
         foreach ($vouchers as $v) {
-            $v->applyTransition('order');
-            $v->applyTransition('print');
             $v->applyTransition('dispatch');
             $v->trader_id = 1;
             $v->applyTransition('collect');
@@ -91,7 +89,7 @@ class TraderModelTest extends TestCase
 
     public function testTraderHasVouchersWithStatus()
     {
-        $vouchers = factory(Voucher::class, 'requested', 6)->create([
+        $vouchers = factory(Voucher::class, 'printed', 6)->create([
             'trader_id' => $this->trader->id,
         ]);
 
@@ -100,8 +98,6 @@ class TraderModelTest extends TestCase
         Auth::login($user);
 
         foreach ($vouchers as $v) {
-            $v->applyTransition('order');
-            $v->applyTransition('print');
             $v->applyTransition('dispatch');
             $v->trader_id = 1;
             $v->applyTransition('collect');

--- a/tests/Unit/Models/VoucherModelMysqlTest.php
+++ b/tests/Unit/Models/VoucherModelMysqlTest.php
@@ -82,12 +82,10 @@ class VoucherModelMysqlTest extends StoreTestCase
     {
         // Make vouchers from them
         foreach ($this->rangeCodes as $rangeCode) {
-            $voucher = factory(Voucher::class, 'requested')->create([
+            $voucher = factory(Voucher::class, 'printed')->create([
                 'code' => $rangeCode,
                 'sponsor_id' => $this->sponsor->id,
             ]);
-            $voucher->applyTransition('order');
-            $voucher->applyTransition('print');
             $voucher->applyTransition('dispatch');
         }
 
@@ -110,12 +108,10 @@ class VoucherModelMysqlTest extends StoreTestCase
     {
         // Make vouchers from them
         foreach ($this->rangeCodes as $rangeCode) {
-            $voucher = factory(Voucher::class, 'requested')->create([
+            $voucher = factory(Voucher::class, 'printed')->create([
                 'code' => $rangeCode,
                 'sponsor_id' => $this->sponsor->id,
             ]);
-            $voucher->applyTransition('order');
-            $voucher->applyTransition('print');
         }
 
         // Make a range to check

--- a/tests/Unit/Models/VoucherModelTest.php
+++ b/tests/Unit/Models/VoucherModelTest.php
@@ -160,11 +160,9 @@ class VoucherModelTest extends TestCase
             'TST0123457'
         ];
         foreach ($goodCodes as $goodCode) {
-            $voucher = factory(Voucher::class, 'requested')->create([
+            $voucher = factory(Voucher::class, 'printed')->create([
                 'code' => $goodCode
             ]);
-            $voucher->applyTransition('order');
-            $voucher->applyTransition('print');
             $voucher->applyTransition('dispatch');
         }
 
@@ -213,17 +211,17 @@ class VoucherModelTest extends TestCase
      */
     public function testItCanCreateAValidTransitionDefinition()
     {
-        $validTransDef = Voucher::createTransitionDef("ordered", "print");
+        $validTransDef = Voucher::createTransitionDef("printed", "dispatch");
 
-        $this->assertEquals('print', $validTransDef->name);
-        $this->assertEquals('ordered', $validTransDef->from);
-        $this->assertNotNull('printed', $validTransDef->to);
+        $this->assertEquals('dispatch', $validTransDef->name);
+        $this->assertEquals('printed', $validTransDef->from);
+        $this->assertNotNull('dispatched', $validTransDef->to);
 
         // Has an invalid transition name
-        $this->assertNull(Voucher::createTransitionDef("ordered", "spacejam!"));
+        $this->assertNull(Voucher::createTransitionDef("printed", "spacejam!"));
 
         // Has an invalid transition "from" state
-        $this->assertNull(Voucher::createTransitionDef("kensington", "printed"));
+        $this->assertNull(Voucher::createTransitionDef("kensington", "dispatched"));
     }
 
     /** @test */
@@ -286,7 +284,7 @@ class VoucherModelTest extends TestCase
         );
 
         foreach ($rangeCodes as $rangeCode) {
-            $voucher = factory(Voucher::class, 'requested')->create([
+            $voucher = factory(Voucher::class, 'printed')->create([
                 'code' => $rangeCode,
                 'sponsor_id' => $sponsor->id,
             ]);

--- a/tests/Unit/Routes/ApiRoutesTest.php
+++ b/tests/Unit/Routes/ApiRoutesTest.php
@@ -24,7 +24,7 @@ class ApiRoutesTest extends TestCase
     {
         parent::setUp();
         $this->trader = factory(Trader::class)->create();
-        $this->vouchers = factory(Voucher::class, 'requested', 10)->create();
+        $this->vouchers = factory(Voucher::class, 'printed', 10)->create();
         $this->user = factory(User::class)->create();
 
         // Set up password client
@@ -58,8 +58,6 @@ class ApiRoutesTest extends TestCase
         // Set up voucher states.
         Auth::login($this->user);
         foreach ($this->vouchers as $v) {
-            $v->applyTransition('order');
-            $v->applyTransition('print');
             $v->delivery_id = $delivery->id;
             $v->applyTransition('dispatch');
         }


### PR DESCRIPTION
https://trello.com/c/qjEN0UY6/1564-remove-printed-and-ordered-states-from-voucher-transitions-there-was-a-bug-so-150k-didnt-have-them-recorded-anyway-and-they-are

- Remove requested and ordered states from system
- Initial voucher state is now printed