### PR TITLE
Guard delete and log with if voucher states exist

### DIFF
--- a/database/migrations/2020_05_21_094708_remove_ordered_printed_from_voucher_states_table.php
+++ b/database/migrations/2020_05_21_094708_remove_ordered_printed_from_voucher_states_table.php
@@ -14,12 +14,17 @@ class RemoveOrderedPrintedFromVoucherStatesTable extends Migration
     public function up()
     {
         Schema::table('voucher_states', function (Blueprint $table) {
+            // We only want to remove this data to production environments.
+            // Seeded environments will not contain these deprecated states.
+            if (!App::environment('production')) {
+                return;
+            }
+
             // I guess nice to have a record of how many rows were deleted?
             $number_to_delete = App\VoucherState::whereIn('to', ['ordered', 'printed'])->count();
-            if ($number_to_delete > 0) {
-                App\VoucherState::whereIn('to', ['ordered', 'printed'])->delete();
-                Log::info($number_to_delete . ' printed and ordered voucher_states records deleted on migration.');
-            }
+            App\VoucherState::whereIn('to', ['ordered', 'printed'])->delete();
+            Log::info($number_to_delete . ' printed and ordered voucher_states records deleted on migration.');
+
         });
     }
 
@@ -35,6 +40,7 @@ class RemoveOrderedPrintedFromVoucherStatesTable extends Migration
             // We could alternatively reconstruct them based on the voucher created_at.
             // This would include some moving around of data since at least 185000 vouchers
             // were missing these states - and we need ids to be same order as timestamps.
+            return;
         });
     }
 }

--- a/database/migrations/2020_05_21_094708_remove_ordered_printed_from_voucher_states_table.php
+++ b/database/migrations/2020_05_21_094708_remove_ordered_printed_from_voucher_states_table.php
@@ -16,9 +16,10 @@ class RemoveOrderedPrintedFromVoucherStatesTable extends Migration
         Schema::table('voucher_states', function (Blueprint $table) {
             // I guess nice to have a record of how many rows were deleted?
             $number_to_delete = App\VoucherState::whereIn('to', ['ordered', 'printed'])->count();
-
-            App\VoucherState::whereIn('to', ['ordered', 'printed'])->delete();
-            Log::info($number_to_delete . ' printed and ordered voucher_states records deleted on migration.');
+            if ($number_to_delete > 0) {
+                App\VoucherState::whereIn('to', ['ordered', 'printed'])->delete();
+                Log::info($number_to_delete . ' printed and ordered voucher_states records deleted on migration.');
+            }
         });
     }
 


### PR DESCRIPTION
https://trello.com/c/SBMdQEq0/1587-do-not-run-remove-order-print-migration-during-testing

- only delete voucher states if in production