### PR TITLE
1.10/1551 void voucher error message with success

### DIFF
--- a/app/Http/Controllers/Service/Admin/DeliveriesController.php
+++ b/app/Http/Controllers/Service/Admin/DeliveriesController.php
@@ -93,7 +93,6 @@ class DeliveriesController extends Controller
 
                 // Bulk update VoucherStates for speed.
                 foreach ($transitions as $transitionDef) {
-                    DB::enableQueryLog();
                     Voucher::select('id')
                         ->whereNull('delivery_id')
                         ->inDefinedRange($rangeDef)

--- a/app/Http/Controllers/Service/Admin/DeliveriesController.php
+++ b/app/Http/Controllers/Service/Admin/DeliveriesController.php
@@ -96,7 +96,8 @@ class DeliveriesController extends Controller
                     DB::enableQueryLog();
                     Voucher::select('id')
                         ->whereNull('delivery_id')
-                        ->withRangedVouchersInState($rangeDef, 'printed')
+                        ->inDefinedRange($rangeDef)
+                        ->inOneOfStates(['printed'])
                         ->chunk(
                             // should be big enough chunks to avoid memory problems
                             10000,

--- a/app/Http/Requests/AdminUpdateVoucherRequest.php
+++ b/app/Http/Requests/AdminUpdateVoucherRequest.php
@@ -30,7 +30,7 @@ class AdminUpdateVoucherRequest extends FormRequest
             // MUST be present, string, exists
             'voucher-start' => 'required|string|exists:vouchers,code',
             // MUST be present, string, exists, greater/equal to start and same sponsor as start
-            'voucher-end' => 'required|string|exists:vouchers,code|codeGreaterThan:voucher-start|sameSponsor:voucher-start',
+            'voucher-end' => 'required|string|exists:vouchers,code|codeGreaterOrEqual:voucher-start|sameSponsor:voucher-start',
             // MUST be present AND be in a subset of transitions
             'transition' => [
                 'required',

--- a/app/Providers/CustomValidationProvider.php
+++ b/app/Providers/CustomValidationProvider.php
@@ -60,6 +60,34 @@ class CustomValidationProvider extends ServiceProvider
         });
 
         /**
+         * Is the supplied voucher code value greater than the the target voucher code value
+         */
+        Validator::extend('codeGreaterOrEqual', function ($attribute, $value, $parameters, $validator) {
+            // Grab the regex matched array
+            $val = Voucher::splitShortcodeNumeric($value);
+
+            // Grab the content of the parameter we pass the rule in a roundabout fashion
+            $otherVal = array_get(
+                $validator->getData(),
+                $parameters[0]
+            );
+
+            if (!empty($otherVal)) {
+                $other = Voucher::splitShortcodeNumeric($otherVal);
+                if (is_numeric($val["number"]) && is_numeric($other["number"])) {
+                    return intval($val["number"]) >= intval($other["number"]);
+                }
+            }
+            // Else "Nope"!
+            return false;
+        });
+
+        Validator::replacer('codeGreaterOrEqual', function ($message, $attribute, $rule, $parameters) {
+            return str_replace(':other', $parameters[0], $message);
+        });
+
+
+        /**
          * Is the supplied voucher value the same sponsor as the target value
          */
         Validator::extend('sameSponsor', function ($attribute, $value, $parameters, $validator) {

--- a/app/Providers/CustomValidationProvider.php
+++ b/app/Providers/CustomValidationProvider.php
@@ -37,18 +37,18 @@ class CustomValidationProvider extends ServiceProvider
          */
         Validator::extend('codeGreaterThan', function ($attribute, $value, $parameters, $validator) {
             // Grab the regex matched array
-            $val = Voucher::splitShortcodeNumeric($value);
+            $code = Voucher::splitShortcodeNumeric($value);
 
             // Grab the content of the parameter we pass the rule in a roundabout fashion
-            $otherVal = array_get(
+            $secondCode = array_get(
                 $validator->getData(),
                 $parameters[0]
             );
 
-            if (!empty($otherVal)) {
-                $other = Voucher::splitShortcodeNumeric($otherVal);
-                if (is_numeric($val["number"]) && is_numeric($other["number"])) {
-                    return intval($val["number"]) > intval($other["number"]);
+            if (!empty($secondCode)) {
+                $other = Voucher::splitShortcodeNumeric($secondCode);
+                if (is_numeric($code["number"]) && is_numeric($other["number"])) {
+                    return intval($code["number"]) > intval($other["number"]);
                 }
             }
             // Else "Nope"!
@@ -64,18 +64,18 @@ class CustomValidationProvider extends ServiceProvider
          */
         Validator::extend('codeGreaterOrEqual', function ($attribute, $value, $parameters, $validator) {
             // Grab the regex matched array
-            $val = Voucher::splitShortcodeNumeric($value);
+            $code = Voucher::splitShortcodeNumeric($value);
 
             // Grab the content of the parameter we pass the rule in a roundabout fashion
-            $otherVal = array_get(
+            $secondCode = array_get(
                 $validator->getData(),
                 $parameters[0]
             );
 
-            if (!empty($otherVal)) {
-                $other = Voucher::splitShortcodeNumeric($otherVal);
-                if (is_numeric($val["number"]) && is_numeric($other["number"])) {
-                    return intval($val["number"]) >= intval($other["number"]);
+            if (!empty($secondCode)) {
+                $other = Voucher::splitShortcodeNumeric($secondCode);
+                if (is_numeric($code["number"]) && is_numeric($other["number"])) {
+                    return intval($code["number"]) >= intval($other["number"]);
                 }
             }
             // Else "Nope"!

--- a/app/Voucher.php
+++ b/app/Voucher.php
@@ -149,6 +149,7 @@ class Voucher extends Model
         return null;
     }
 
+
     /**
      * Creates a rangeDef structure
      * TODO: convert to class?
@@ -174,6 +175,12 @@ class Voucher extends Model
         return (object) $rangeDef;
     }
 
+    public static function collectionHasVoidable($currentstates)
+    {
+        $voidable_states = ['printed', 'dispatched'];
+        return true;
+    }
+
     /**
      * Determines if the given voucher range contains entries already delivered
      *
@@ -183,19 +190,6 @@ class Voucher extends Model
     public static function rangeIsDeliverable($rangeDef)
     {
         $ranges = self::getDeliverableVoucherRangesByShortCode($rangeDef->shortcode);
-        $range = self::getContainingRange($rangeDef->start, $rangeDef->end, $ranges);
-        return (!is_null($range) && is_object($range));
-    }
-
-    /**
-     * Determines if the given voucher range cannot be voided
-     *
-     * @param $rangeDef object { 'start', 'end', 'shortcode', 'sponsor_id' }
-     * @return bool
-     */
-    public static function rangeIsVoidable($rangeDef)
-    {
-        $ranges = self::getVoidableVoucherRangesByShortCode($rangeDef->shortcode);
         $range = self::getContainingRange($rangeDef->start, $rangeDef->end, $ranges);
         return (!is_null($range) && is_object($range));
     }
@@ -218,96 +212,6 @@ class Voucher extends Model
              return $matches;
         } else {
             return false;
-        }
-    }
-
-    /**
-     * Gets ranges of the vouchers that *can* be voided, by a Sponsor's shortcode.
-     *
-     * @param string $shortcode
-     * @return array
-     */
-    public static function getVoidableVoucherRangesByShortCode(string $shortcode)
-    {
-        try {
-            return DB::transaction(function () use ($shortcode) {
-                // Set some important variables for the query. breaks SQLlite.
-                DB::statement(DB::raw('SET @initial_id=0, @start=0, @previous=0;'));
-
-                /* This seems to be the fastest way to find the start and end of each "range" of vouchers;
-                 * in this case specified by vouchers that are not in deliveries.
-                 * returns an array of stdClass objects with
-                 * - serial; the final serial number in the range
-                 * - start; the initial serial in the range
-                 * - final_code; the code associated with serial
-                 * - initial_code; the code associated with the start
-                 * - id; the voucher id of the serial
-                 * - initial_id; the voucher id of the start
-                 */
-                // TODO: convert to eloquent
-                return DB::select(
-                    "
-                    SELECT
-                        t1.*,
-                        v1.code as intitial_code,
-                        v2.code as final_code
-                    FROM (
-
-                        SELECT
-                            @start := if(end - @previous = 1, @start, end) as start,
-                            @initial_id := if(end - @previous = 1, @initial_id, id) as initial_id,
-                            @previous := end as end,
-                            id as final_id
-                        FROM (
-
-                            SELECT id, cast(replace(code, '{$shortcode}', '') as signed) as end
-                            FROM vouchers
-                            WHERE code REGEXP '^{$shortcode}[0-9]+\$'
-                              AND currentstate = 'dispatched'
-                            ORDER BY end
-
-                        ) as t5
-
-                    ) AS t1
-                        INNER JOIN (
-
-                            SELECT start, max(end) as final
-                            FROM (
-
-                                 SELECT
-                                     @start := if(end - @previous = 1, @start, end) as start,
-                                     @initial_id := if(end - @previous = 1, @initial_id, id) as initial_id,
-                                     @previous := end as end,
-                                     id
-                                 FROM (
-
-                                    SELECT id, cast(replace(code, '{$shortcode}', '') as signed) as end
-                                    FROM vouchers
-                                    WHERE code REGEXP '^{$shortcode}[0-9]+\$'
-                                      AND currentstate = 'dispatched'
-                                    ORDER BY end
-
-                                 ) as t4
-
-                            ) as t3
-                            GROUP BY start
-
-                        ) as t2
-                        ON t1.start = t2.start
-                          AND t1.end = t2.final
-
-                    LEFT JOIN vouchers as v1
-                        ON initial_id = v1.id
-
-                    LEFT JOIN vouchers as v2
-                        ON final_id = v2.id
-                    "
-                );
-            });
-        } catch (Throwable $e) {
-            Log::error('Bad transaction for ' . __CLASS__ . '@' . __METHOD__ . ' by service user ' . Auth::id());
-            Log::error($e->getTraceAsString());
-            return [];
         }
     }
 
@@ -538,22 +442,51 @@ class Voucher extends Model
     }
 
     /**
-     * Gets a set of vouchers that share a shortcode and currentstate in a sponsor
+     * Gets a set of vouchers in a range using shortcode, sponsor and voucher number.
      *
      * @param Builder $query
      * @param object $rangeDef
-     * @param string $state State if interest
      * @return Builder
      */
-    public function scopeWithRangedVouchersInState(Builder $query, $rangeDef, $state)
+    public function scopeInDefinedRange($query, $rangeDef)
     {
         return $query
-            ->where('currentstate', $state)
             ->where('code', 'REGEXP', "^{$rangeDef->shortcode}[0-9]+\$") // Just vouchers that start with our shortcode
             ->where('sponsor_id', $rangeDef->sponsor_id) // that are in the sponsor (performance, using the index)
             ->whereBetween(
                 DB::raw("cast(replace(code, '{$rangeDef->shortcode}', '') as signed)"),
                 [$rangeDef->start, $rangeDef->end]
             );
+
     }
+
+    /**
+     * Gets a set of vouchers that are in one of given states.
+     *
+     * @param Builder $query
+     * @param array $states
+     * @return Builder
+     */
+    public function scopeInOneOfStates(Builder $query, $states)
+    {
+        return $query
+            ->whereIn('currentstate', $states)
+        ;
+    }
+
+    /**
+     * Gets a set of vouchers that are voidable.
+     *
+     * @param Builder $query
+     * @param array $states
+     * @return Builder
+     */
+    public function scopeInVoidableState(Builder $query)
+    {
+        $voidable_states = ['dispatched'];
+        return $query
+            ->inOneOfStates($voidable_states)
+        ;
+    }
+
 }

--- a/app/Voucher.php
+++ b/app/Voucher.php
@@ -175,12 +175,6 @@ class Voucher extends Model
         return (object) $rangeDef;
     }
 
-    public static function collectionHasVoidable($currentstates)
-    {
-        $voidable_states = ['printed', 'dispatched'];
-        return true;
-    }
-
     /**
      * Determines if the given voucher range contains entries already delivered
      *

--- a/resources/lang/en/service.php
+++ b/resources/lang/en/service.php
@@ -5,9 +5,9 @@ return [
         'vouchers_create' => [
             'success' => 'Created and activated :shortcode :start to :shortcode :end',
         ],
-        'vouchers_batchtransition' => [
-            'blocked' => 'The voucher range given contains some vouchers that are not voidable',
-            'success' => 'Vouchers :shortcode :start to :shortcode :end have been :transition_to',
+        'vouchers_batchretiretransition' => [
+            'blocked' => 'The voucher range given does not contain any vouchers that are voidable',
+            'success' => ':success_codes have been :transition_to. :fail_code_details',
         ],
         'vouchers_delivery' => [
             'blocked' => 'The voucher range given contains some vouchers that have already been delivered',

--- a/resources/views/service/includes/sidebar.blade.php
+++ b/resources/views/service/includes/sidebar.blade.php
@@ -26,10 +26,4 @@
         @endUnless
     </ul>
 
-    @if (session('notification'))
-        <div class="alert alert-success">
-            {{ session('notification') }}
-        </div>
-    @endif
-
 </div>

--- a/resources/views/service/layouts/app.blade.php
+++ b/resources/views/service/layouts/app.blade.php
@@ -72,6 +72,11 @@
                 </div>
             </div>
         </nav>
+        @if (session('notification'))
+        <div class="alert alert-success">
+            {{ session('notification') }}
+        </div>
+         @endif
 
         @yield('content')
     </div>

--- a/resources/views/service/vouchers/void.blade.php
+++ b/resources/views/service/vouchers/void.blade.php
@@ -13,7 +13,7 @@
             @endif
             <p>Use the form below to mark a batch of vouchers as "Void" or "Expired". Add start and end voucher codes of the batch.</p>
 
-            <form role="form" class="styled-form" method="POST" action="{{ route('admin.vouchers.updatebatch') }}">
+            <form role="form" class="styled-form" method="POST" action="{{ route('admin.vouchers.retirebatch') }}">
                 {!! method_field("PATCH") !!}
                 {!! csrf_field() !!}
                 <div class="container">
@@ -28,7 +28,7 @@
                                    required >
                             @include('service.partials.validationMessages', array('inputName' => 'voucher-start'))
                         </div>
-                        <div class="col-sm-6 col-lg-9">
+                        <div class="col-sm-6 col-lg-3">
                             <label for="voucher-end" class="required">End Voucher</label>
                             <input type="text"
                                    id="voucher-end"
@@ -43,7 +43,7 @@
                         <div class="col-sm-6 col-lg-3">
                             <button type="submit" name="transition" value="expire">Expire vouchers</button>
                         </div>
-                        <div class="col-sm-6 col-lg-9">
+                        <div class="col-sm-6 col-lg-3">
                             <button type="submit" name="transition" value="void">Void vouchers</button>
                         </div>
                     </div>

--- a/routes/service.php
+++ b/routes/service.php
@@ -50,8 +50,8 @@ Route::group(['middleware' => 'auth:admin'], function () {
     ]);
     // ...patch because changing state of a partial collection of vouchers.
     Route::patch('vouchers', [
-        'as' => 'admin.vouchers.updatebatch',
-        'uses' => 'Admin\VouchersController@updateBatch',
+        'as' => 'admin.vouchers.retirebatch',
+        'uses' => 'Admin\VouchersController@retireBatch',
     ]);
 
     // Worker Management

--- a/tests/Unit/Controllers/Service/Admin/VoucherControllerMysqlTest.php
+++ b/tests/Unit/Controllers/Service/Admin/VoucherControllerMysqlTest.php
@@ -97,15 +97,14 @@ class VoucherControllerMysqlTest extends StoreTestCase
 
         // Set some routes
         $formRoute = route('admin.vouchers.void');
-        $requestRoute = route('admin.vouchers.updatebatch');
+        $requestRoute = route('admin.vouchers.retirebatch');
         $successRoute = route('admin.vouchers.index');
 
         // Set the message to look for
-        $msg = trans('service.messages.vouchers_batchtransition.success', [
+        $msg = trans('service.messages.vouchers_batchretiretransition.success', [
             'transition_to' => 'retired',
-            'shortcode' => 'TST',
-            'start' => 102,
-            'end' => 104,
+            'success_codes' => 'TST102 TST103 TST104 ',
+            'fail_code_details' => '',
         ]);
 
         // Make the patch
@@ -145,15 +144,14 @@ class VoucherControllerMysqlTest extends StoreTestCase
 
             // Set some routes
             $formRoute = route('admin.vouchers.void');
-            $requestRoute = route('admin.vouchers.updatebatch');
+            $requestRoute = route('admin.vouchers.retirebatch');
             $successRoute = route('admin.vouchers.index');
 
             // Set the message to look for
-            $msg = trans('service.messages.vouchers_batchtransition.success', [
+            $msg = trans('service.messages.vouchers_batchretiretransition.success', [
                 'transition_to' => 'retired',
-                'shortcode' => 'TST',
-                'start' => 102,
-                'end' => 104,
+                'success_codes' => 'TST102 TST103 TST104 ',
+                'fail_code_details' => '',
             ]);
 
             // Make the patch

--- a/tests/Unit/Models/VoucherModelMysqlTest.php
+++ b/tests/Unit/Models/VoucherModelMysqlTest.php
@@ -77,31 +77,6 @@ class VoucherModelMysqlTest extends StoreTestCase
         Auth::login($this->user);
     }
 
-    /** @test */
-    public function testItCanGetVoidableVouchersByShortcode()
-    {
-        // Make vouchers from them
-        foreach ($this->rangeCodes as $rangeCode) {
-            $voucher = factory(Voucher::class, 'printed')->create([
-                'code' => $rangeCode,
-                'sponsor_id' => $this->sponsor->id,
-            ]);
-            $voucher->applyTransition('dispatch');
-        }
-
-        // Make a range to check
-        $inBoundsRange = Voucher::createRangeDefFromVoucherCodes('TST0102', 'TST0104');
-
-        // Check it.
-        $ranges = Voucher::getVoidableVoucherRangesByShortCode($inBoundsRange->shortcode);
-        $this->assertCount(3, $ranges);
-        $this->assertEquals(101, $ranges[0]->start);
-        $this->assertEquals(105, $ranges[0]->end);
-        $this->assertEquals(201, $ranges[1]->start);
-        $this->assertEquals(205, $ranges[1]->end);
-        $this->assertEquals(301, $ranges[2]->start);
-        $this->assertEquals(305, $ranges[2]->end);
-    }
 
     /** @test */
     public function testItCanGetDeliverableVouchersByShortcode()


### PR DESCRIPTION
https://trello.com/c/6Ep7bSZL/1551-vouchers-that-have-already-been-paid-or-recorded-for-payment-cannot-be-marked-as-void-specify-voucher-in-error-message-eee-v

- Allow batches of void vouchers to contain non-voidable.
- success details contain list of unvoidable vouchers.

There is certainly room for improvement, this is a first hack.