### PR TITLE
1.12/1645 remove need for hand inputting numbers and just scan only fraud response

### DIFF
--- a/app/Http/Controllers/API/TraderController.php
+++ b/app/Http/Controllers/API/TraderController.php
@@ -54,6 +54,16 @@ EOD;
         }
 
         $traders = Auth::user()->traders;
+        foreach ($traders as $trader) {
+            $sponsor = $trader->market->sponsor;
+            if ($sponsor->can_tap === false) {
+                $trader->featureOverride = (object)[
+                    "pageAccess" => (object)[
+                        "tap" => false
+                    ]
+                ];
+            }
+        }
 
         return response()->json($traders, 200);
     }

--- a/app/Sponsor.php
+++ b/app/Sponsor.php
@@ -20,6 +20,7 @@ class Sponsor extends Model
     protected $fillable = [
         'name',
         'shortcode',
+        'can_tap'
     ];
 
     /**
@@ -28,6 +29,15 @@ class Sponsor extends Model
      * @var array
      */
     protected $hidden = [
+    ];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'can_tap' => 'boolean',
     ];
 
     /**

--- a/database/migrations/2020_12_15_141709_update_sponsors_add_can_tap_bool.php
+++ b/database/migrations/2020_12_15_141709_update_sponsors_add_can_tap_bool.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class UpdateSponsorsAddCanTapBool extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('sponsors', function (Blueprint $table) {
+            $table->boolean('can_tap')->default(true);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('sponsors', function (Blueprint $table) {
+            $table->dropColumn('can_tap');
+        });
+    }
+}

--- a/database/seeds/MarketsSeeder.php
+++ b/database/seeds/MarketsSeeder.php
@@ -38,6 +38,12 @@ class MarketsSeeder extends Seeder
                 'name' => "Cedar Terrace",
                 'payment_message' => 'Please mark your vouchers with the stall name and return to the office.',
             ],
+            [
+                'name' => "No Tap Farm",
+                'location' => 'Happy Farm',
+                'sponsor_id' => 7,
+                'payment_message' => 'Please post your vouchers to the office.',
+            ],
         ];
 
         foreach ($marketsData as $market) {

--- a/database/seeds/SponsorsSeeder.php
+++ b/database/seeds/SponsorsSeeder.php
@@ -42,6 +42,10 @@ class SponsorsSeeder extends Seeder
 
         // 4MAY20-VC1-CH1P-HA-012020 is in sponsor 5, unmodified
         // 1MAY20a-VC2-CH1-HI-042019 is in sponsor 5, unmodified
+
+        $noTapSponsor = factory(App\Sponsor::class)->create(['name' => "No Tap Project", "can_tap" => false]);
+        $noTapSponsor->evaluations()->saveMany($this->qualifyPrimarySchoolers());
+        $noTapSponsor->evaluations()->saveMany($this->veryfiesKids());
     }
 
     public function veryfiesKids()

--- a/database/seeds/TradersSeeder.php
+++ b/database/seeds/TradersSeeder.php
@@ -36,6 +36,10 @@ class TradersSeeder extends Seeder
                 'name' => "Sally's Fruit Stall",
                 'market_id' => 5,
             ],
+            [
+                'name' => "Jane's Farm Produce",
+                'market_id' => 6
+            ],
         ];
 
         foreach ($tradersData as $trader) {

--- a/database/seeds/UsersSeeder.php
+++ b/database/seeds/UsersSeeder.php
@@ -60,5 +60,8 @@ class UsersSeeder extends Seeder
 
         // So we reliably have one user who can act on behalf of all traders.
         $users[3]->traders()->sync($traders);
+
+        // So we reliably have a specific user who cannot access the tap page
+        $users[1]->traders()->sync($traders[6]);
     }
 }

--- a/tests/Unit/Controllers/Api/TraderControllerTest.php
+++ b/tests/Unit/Controllers/Api/TraderControllerTest.php
@@ -85,6 +85,7 @@ class TraderControllerTest extends TestCase
             'sponsor_shortcode' => $trader->market->sponsor_shortcode,
             'payment_message' => $trader->market->payment_message,
         ]);
+        dd($response);
     }
 
     public function testShowVoucherHistoryCompilesListOfPaymentHistory()

--- a/tests/Unit/Controllers/Api/TraderControllerTest.php
+++ b/tests/Unit/Controllers/Api/TraderControllerTest.php
@@ -72,6 +72,11 @@ class TraderControllerTest extends TestCase
         $response = $this->actingAs($this->user, 'api')
             ->get(route('api.traders', $trader->id));
         $response->assertStatus(200);
+        $response->assertJsonStructure([
+            [
+                "id", "name", "pic_url", "market_id", "featureOverride"
+            ]
+        ]);
         /**
          * TODO: This is not as good as the assertJsonStructure but that requires phpunit 7.5
          * * And the mail assertions won't let us upgrade.  This will need to be revisited in the future.
@@ -85,7 +90,6 @@ class TraderControllerTest extends TestCase
             'sponsor_shortcode' => $trader->market->sponsor_shortcode,
             'payment_message' => $trader->market->payment_message,
         ]);
-        dd($response);
     }
 
     public function testShowVoucherHistoryCompilesListOfPaymentHistory()

--- a/tests/Unit/Controllers/Api/TraderControllerTest.php
+++ b/tests/Unit/Controllers/Api/TraderControllerTest.php
@@ -6,6 +6,7 @@ use App\Market;
 use App\Voucher;
 use App\Trader;
 use App\User;
+use App\Sponsor;
 use App\Http\Controllers\API\TraderController;
 use Auth;
 use Carbon\Carbon;
@@ -56,20 +57,25 @@ class TraderControllerTest extends TestCase
      *
      * Asserts that the correct JSON structure is returned along with the correct market data.
      */
-    public function testTradersControllerIndex() {
+    public function testTradersControllerIndex()
+    {
         $trader = factory(Trader::class)->create(
             [
-                'market_id' => factory(Market::class)->create()->id,
+                'market_id' => factory(Market::class)->create([
+                    'sponsor_id' => factory(Sponsor::class)->create(["can_tap" => false])->id,
+                ])->id,
             ]
         );
 
         $this->user->traders()->sync([$trader->id]);
+
         $response = $this->actingAs($this->user, 'api')
             ->get(route('api.traders', $trader->id));
         $response->assertStatus(200);
-        // This is not as good as the assertJsonStructure but that requires phpunit 7.5
-        // And the mail assertions won't let us upgrade.  This will need to be revisited
-        // in the future.
+        /**
+         * TODO: This is not as good as the assertJsonStructure but that requires phpunit 7.5
+         * * And the mail assertions won't let us upgrade.  This will need to be revisited in the future.
+        */
         $response->assertJsonPath("0.id", 3);
         $response->assertJsonPath("0.market_id", 1);
         $response->assertJsonPath("0.id", 3);
@@ -135,7 +141,8 @@ class TraderControllerTest extends TestCase
             ->assertStatus(202)
             ->assertJson([
                 'message' => trans(
-                    'api.messages.email_voucher_history_date', [
+                    'api.messages.email_voucher_history_date',
+                    [
                         'date' => $date,
                     ]
                 )


### PR DESCRIPTION
### Trello :ticket: 🔗 [https://trello.com/c/2Hq6Y6cc/1645-remove-need-for-hand-inputting-numbers-and-just-scan-only-fraud-response-vvv-eee](https://trello.com/c/2Hq6Y6cc/1645-remove-need-for-hand-inputting-numbers-and-just-scan-only-fraud-response-vvv-eee)

Linked to this:  neontribe/ARCVMarket#222