### PR TITLE
fix typo

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/carbon
+lts/erbium

--- a/app/Http/Controllers/Service/Admin/MarketsController.php
+++ b/app/Http/Controllers/Service/Admin/MarketsController.php
@@ -51,7 +51,7 @@ class MarketsController extends Controller
                     'name' => $request->input('name'),
                     'sponsor_id' => $sponsor->id,
                     'location' => $sponsor->name,
-                    'payment_message' => $request->input('payment_pending')
+                    'payment_message' => $request->input('payment_message')
                 ]);
                 $m->save();
 


### PR DESCRIPTION
Whoops! something autocorrect must have snuck a `pending` in where a `message` was required

https://trello.com/c/BWWAqTDT/1684-bug-marketscontroller-references-paymentpending-not-paymentmessage