### PR TITLE
Fix group by

### DIFF
--- a/app/Http/Controllers/API/Auth/LoginProxy.php
+++ b/app/Http/Controllers/API/Auth/LoginProxy.php
@@ -44,6 +44,11 @@ class LoginProxy
      */
     public function attemptLogin($email, $password)
     {
+        /*
+         * So SQLLite and MySQL treat "having" differently
+         * - SQLLite requires a "group by" for a "having"
+         * - MySQL is happy to assume a single group if unspecified.
+         */
         // fetch the users with the email
         $user = User::where('email', $email)
             // that have at least one enabled
@@ -52,7 +57,9 @@ class LoginProxy
                     return $query->whereNull('traders.disabled_at');
                 },
             ])
-            ->where('traders_count', '>', 0)
+            // group on email to keep SQLlite happy
+            ->groupBy('email')
+            ->having('traders_count', '>', 0)
             ->first();
 
         if (!is_null($user)) {

--- a/app/Http/Controllers/Service/Admin/TradersController.php
+++ b/app/Http/Controllers/Service/Admin/TradersController.php
@@ -221,6 +221,8 @@ class TradersController extends Controller
                 // find any users that have just been deleted and have *no other* traders
                 $orphanUsers = User::whereIn('id', $origUserIds)
                     ->withCount('traders')
+                    // to keep SQLite happy
+                    ->groupBy('id')
                     ->having('traders_count', '=', 0)
                     ->pluck('id')
                     ->toArray();


### PR DESCRIPTION
First, it needs to be a "having", rather than a "where", when processing the computed value;

Secondly, SQLite and MySQL treat "having" differently
- SQLite likes to have everything grouped
- MySQL doesn't care

So we put a `groupBy('<some uid in the query>')` to keep SQLite happy