### PR TITLE
1.13/1798 hotfix history performance

### DIFF
--- a/app/Http/Controllers/API/TraderController.php
+++ b/app/Http/Controllers/API/TraderController.php
@@ -109,7 +109,7 @@ class TraderController extends Controller
                     ->where('voucher_states.to', 'payment_pending')
                     ->where('vouchers.trader_id', $trader->id)
                     // cut down the recorded
-                    ->whereNotIn('vouchers.currentstate', '!=', 'recorded')
+                    ->where('vouchers.currentstate', '!=', 'recorded')
                     ->groupBy('pendedOn')
                     ->orderByDesc('pendedOn');
         }, 'daysFromQuery')

--- a/app/Http/Controllers/API/TraderController.php
+++ b/app/Http/Controllers/API/TraderController.php
@@ -104,14 +104,16 @@ class TraderController extends Controller
         $pgSubDates = DB::table(static function ($query) use ($trader) {
                 $query->selectRaw("SUBSTR(`voucher_states`.`created_at`, 1, 10) as pendedOn")
                     ->from('vouchers')
-                    ->leftJoin('voucher_states', 'vouchers.id', 'voucher_states.voucher_id')
+                    // use inner join
+                    ->join('voucher_states', 'vouchers.id', 'voucher_states.voucher_id')
                     ->where('voucher_states.to', 'payment_pending')
                     ->where('vouchers.trader_id', $trader->id)
                     // cut down the recorded
-                    ->where('vouchers.currentstate', '!=', 'recorded')
+                    ->whereNotIn('vouchers.currentstate', '!=', 'recorded')
                     ->groupBy('pendedOn')
                     ->orderByDesc('pendedOn');
         }, 'daysFromQuery')
+            ->select('pendedOn')
             ->paginate()
             ->toArray();
 
@@ -259,7 +261,8 @@ class TraderController extends Controller
                     ->orderByDesc('id')
                     ->limit(1),
             ])
-            ->leftJoin('voucher_states', 'vouchers.id', 'voucher_states.voucher_id')
+             // use inner join
+            ->join('voucher_states', 'vouchers.id', 'voucher_states.voucher_id')
             ->where('voucher_states.to', 'payment_pending')
             ->where('vouchers.trader_id', $trader->id)
             ->whereBetween('voucher_states.created_at', [$fromDate, $toDate])

--- a/app/Http/Controllers/API/TraderController.php
+++ b/app/Http/Controllers/API/TraderController.php
@@ -74,12 +74,19 @@ class TraderController extends Controller
         // GET api/traders/{trader}/vouchers?status=unpaid
         // Find all vouchers that belong to {trader}
         // that have not had a GIVEN status as a voucher_state IN THEIR LIVES.
-        $updated_at_sql = self::dateMangler('updated_at', '%d-%m-%Y', 'updated_at');
+
+        // horrid mangler to make sqlite tests work because it functions differ
+        // worth the performance increase though
+        $connection = config('database.default');
+        $dateMangler = config("database.connections.{$connection}.driver") === "sqlite"
+            ? "STRFTIME('%d-%m-%Y', updated_at) as updated_at"
+            : 'DATE_FORMAT(updated_at,"%d-%m-%Y") as updated_at'
+        ;
 
         $status = request()->input('status');
         $vouchers = $trader->vouchersWithStatus($status, [
             'code',
-            \DB::raw($updated_at_sql)
+            \DB::raw($dateMangler)
         ]);
         return response()->json($vouchers);
     }
@@ -102,7 +109,7 @@ class TraderController extends Controller
                     ->where('voucher_states.to', 'payment_pending')
                     ->where('vouchers.trader_id', $trader->id)
                     // cut down the recorded
-                    ->where('vouchers.currentstate', '!=', 'recorded')
+                    ->whereNotIn('vouchers.currentstate', '!=', 'recorded')
                     ->groupBy('pendedOn')
                     ->orderByDesc('pendedOn');
         }, 'daysFromQuery')
@@ -123,7 +130,6 @@ class TraderController extends Controller
 
             // process the data into an array
             $data = self::historyGroupByDate($histories);
-            $json = json_encode($data);
         }
 
         $links = implode(', ', [
@@ -241,19 +247,15 @@ class TraderController extends Controller
      */
     public static function paymentHistoryBetweenDateTimes(Trader $trader, string $fromDate, string $toDate) : Collection
     {
-        $created_at_sql = self::dateMangler('created_at', '%d-%m-%Y', 'created_at');
-        $pended_on = self::dateMangler('voucher_states.created_at', '%d-%m-%Y', 'pended_on');
-        $pended_on_ymd = self::dateMangler('voucher_states.created_at', '%Y-%m-%d', 'pended_on_ymd');
-
          return DB::table('vouchers')
-            ->select(DB::raw("code, $pended_on_ymd, $pended_on"))
+            ->select(['vouchers.code', 'voucher_states.created_at as payment_pending'])
             ->addSelect([
-                'recorded_on' => VoucherState::select(DB::raw($created_at_sql))
+                'recorded' => VoucherState::select('created_at')
                     ->whereColumn('voucher_id', 'vouchers.id')
                     ->where('to', 'recorded')
                     ->orderByDesc('id')
                     ->limit(1),
-                'reimbursed_on' => VoucherState::select(DB::raw($created_at_sql))
+                'reimbursed' => VoucherState::select('created_at')
                     ->whereColumn('voucher_id', 'vouchers.id')
                     ->where('to', 'reimbursed')
                     ->orderByDesc('id')
@@ -264,7 +266,7 @@ class TraderController extends Controller
             ->where('voucher_states.to', 'payment_pending')
             ->where('vouchers.trader_id', $trader->id)
             ->whereBetween('voucher_states.created_at', [$fromDate, $toDate])
-            ->orderByDesc('pended_on_ymd')
+            ->orderByDesc('recorded')
             ->get();
     }
 
@@ -277,44 +279,30 @@ class TraderController extends Controller
     {
         $data = [];
         foreach ($histories as $history) {
+            // create a record for this voucher
+            $voucher = [
+                    'code' => $history->code,
+                    'recorded_on' => $history->recorded
+                        ? Carbon::createFromFormat('Y-m-d H:i:s', $history->recorded)->format('d-m-Y')
+                        : '',
+                    'reimbursed_on' => $history->reimbursed
+                        ? Carbon::createFromFormat('Y-m-d H:i:s', $history->reimbursed)->format('d-m-Y')
+                        : '',
+                ];
+
             // work out the d-m-Y it belongs to.
-            $pended_on_ymd = $history->pended_on_ymd;
-            $pended_on = $history->pended_on;
+            $pended_on = Carbon::createFromFormat('Y-m-d H:i:s', $history->payment_pending)->format('d-m-Y');
 
             // if there's not a d-m-Y record to hold it, make one
-            if (!isset($data[$pended_on_ymd])) {
-                $data[$pended_on_ymd] = [
+            if (!isset($data[$pended_on])) {
+                $data[$pended_on] = [
                     'pended_on' => $pended_on,
                     'vouchers' => []
                 ];
             }
             // append the new record voucher to the d-m-Y place vouchers on the tree.
-            $data[$pended_on_ymd]['vouchers'][] = [
-                'code' => $history->code,
-                'recorded_on' => $history->recorded_on,
-                'reimbursed_on' => $history->reimbursed_on,
-            ];
+            $data[$pended_on]['vouchers'][] = $voucher;
         }
         return $data;
-    }
-
-    /**
-     * Horrid mangler to make sqlite tests work because it functions differ.
-     * worth the performance increase though
-     * @param string $field
-     * @param string $format
-     * @return string
-     */
-    public static function dateMangler(string $field, string $format, string $alias = null): string
-    {
-        $connection = config('database.default');
-        $format =  config("database.connections.{$connection}.driver") === "sqlite"
-            ? "STRFTIME('$format', $field)"
-            : "DATE_FORMAT($field, \"$format\")"
-        ;
-        return (isset($alias))
-            ? "$format as $alias"
-            : $format
-        ;
     }
 }

--- a/app/Http/Controllers/API/TraderController.php
+++ b/app/Http/Controllers/API/TraderController.php
@@ -107,6 +107,8 @@ class TraderController extends Controller
                     ->leftJoin('voucher_states', 'vouchers.id', 'voucher_states.voucher_id')
                     ->where('voucher_states.to', 'payment_pending')
                     ->where('vouchers.trader_id', $trader->id)
+                    // cut down the recorded
+                    ->where('voucher.currentstate', '!=', 'recorded')
                     ->groupBy('pendedOn')
                     ->orderByDesc('pendedOn');
         }, 'daysFromQuery')

--- a/app/Http/Controllers/API/TraderController.php
+++ b/app/Http/Controllers/API/TraderController.php
@@ -108,7 +108,7 @@ class TraderController extends Controller
                     ->where('voucher_states.to', 'payment_pending')
                     ->where('vouchers.trader_id', $trader->id)
                     // cut down the recorded
-                    ->where('voucher.currentstate', '!=', 'recorded')
+                    ->where('vouchers.currentstate', '!=', 'recorded')
                     ->groupBy('pendedOn')
                     ->orderByDesc('pendedOn');
         }, 'daysFromQuery')

--- a/database/migrations/2022_03_24_095936_add_voucher_states_composite_to_voucherid_index.php
+++ b/database/migrations/2022_03_24_095936_add_voucher_states_composite_to_voucherid_index.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddVoucherStatesCompositeToVoucheridIndex extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up(): void
+    {
+        Schema::table('voucher_states', static function (Blueprint $table) {
+            $sm = Schema::getConnection()->getDoctrineSchemaManager();
+            $indexesFound = $sm->listTableIndexes('voucher_states');
+
+            if (!array_key_exists("voucher_states_to_voucher_id_index", $indexesFound)) {
+                $table->index(['to', 'voucher_id']);
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down(): void
+    {
+        Schema::table('voucher_states', static function (Blueprint $table) {
+            $sm = Schema::getConnection()->getDoctrineSchemaManager();
+            $indexesFound = $sm->listTableIndexes('voucher_states');
+
+            if (array_key_exists("voucher_states_to_voucher_id_index", $indexesFound)) {
+                $table->dropIndex("voucher_states_to_voucher_id_index");
+            }
+        });
+    }
+}


### PR DESCRIPTION
Changes to speed up things a little.
https://trello.com/c/GC94NpEi/1798-hotfix-history-performance

Turns out inner joins in the context are much faster than left joins, as inner joins don't bring back a bunch of null columns
https://www.sqlshack.com/learn-sql-inner-join-vs-left-join/