### PR TITLE
1.14/1844 a centre can determine its mode vvv ee

### DIFF
--- a/app/Sponsor.php
+++ b/app/Sponsor.php
@@ -21,6 +21,7 @@ class Sponsor extends Model
         'name',
         'shortcode',
         'can_tap',
+        'programme',
     ];
 
     /**

--- a/app/Sponsor.php
+++ b/app/Sponsor.php
@@ -43,6 +43,7 @@ class Sponsor extends Model
      */
     protected $casts = [
         'can_tap' => 'boolean',
+        'programme' => 'integer',
     ];
 
     /**

--- a/app/Sponsor.php
+++ b/app/Sponsor.php
@@ -24,6 +24,10 @@ class Sponsor extends Model
         'programme',
     ];
 
+    protected $appends = [
+        'programme_name',
+    ];
+
     /**
      * The attributes that should be hidden for arrays.
      *
@@ -40,6 +44,16 @@ class Sponsor extends Model
     protected $casts = [
         'can_tap' => 'boolean',
     ];
+
+    /**
+     * Gets an english version of the programme name
+     *
+     * @return mixed
+     */
+    public function getProgrammeNameAttribute()
+    {
+        return config('arc.programmes')[$this->programme];
+    }
 
     /**
      * Get the vouchers associated with this Sponsor.

--- a/config/arc.php
+++ b/config/arc.php
@@ -98,7 +98,7 @@ return [
     |--------------------------------------------------------------------------
      */
     'programmes' => [
-        'standard',
-        'social prescribing',
+        'Standard',
+        'Social Prescribing',
     ],
 ];

--- a/config/arc.php
+++ b/config/arc.php
@@ -91,4 +91,14 @@ return [
     */
     'first_delivery_date' => env('ARC_FIRST_DELIVERY_DATE', '2019-09-26'),
 
+    /*
+    |--------------------------------------------------------------------------
+    | the programme names we are running
+    | eg. "standard", "social prescribing"
+    |--------------------------------------------------------------------------
+     */
+    'programmes' => [
+        'standard',
+        'social prescribing',
+    ],
 ];

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -88,7 +88,7 @@ $factory->defineAs(App\CentreUser::class, 'FMUser',function (Faker\Generator $fa
 /**
  * Sponsor for testing
  */
-$factory->define(App\Sponsor::class, function (Faker\Generator $faker) {
+$factory->define(App\Sponsor::class, function (Faker\Generator $faker, array $attributes = []) {
 
     $counties = [
         "Barnfordshire",
@@ -139,10 +139,12 @@ $factory->define(App\Sponsor::class, function (Faker\Generator $faker) {
 
     $index = $faker->unique()->numberBetween(0, 43);
 
-    return [
+    $data = [
         'name' => $counties[$index],
         'shortcode' => $faker->regexify('[A-Z]{4}'),
     ];
+
+    return array_merge($attributes, $data);
 });
 
 /**

--- a/database/migrations/2022_05_23_134442_add_programme_to_sponsor.php
+++ b/database/migrations/2022_05_23_134442_add_programme_to_sponsor.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddProgrammeToSponsor extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('sponsors', static function (Blueprint $table) {
+            $table->integer('programme')
+                ->after('shortcode')
+                ->default(0)
+            ;
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('sponsors', static function (Blueprint $table) {
+            $table->dropColumn(['programme']);
+        });
+    }
+}
+

--- a/database/seeds/CentreUsersSeeder.php
+++ b/database/seeds/CentreUsersSeeder.php
@@ -69,5 +69,14 @@ class CentreUsersSeeder extends Seeder
         $deletedUsers = factory(App\CentreUser::class, 2)->create([
             "deleted_at"  => date("Y-m-d H:i:s"),
         ]);
+
+        // an SP user for testing
+        $socialPrescriber = factory(App\CentreUser::class)->create([
+            'name' => 'prescribing user',
+            'email' => 'arc+spuser@neontribe.co.uk',
+            "password" => bcrypt('store_pass'),
+        ]);
+        $spcId = App\Centre::where('name', 'Prescribing Centre')->first()->id;
+        $socialPrescriber->centres()->attach($spcId, ["homeCentre" => true]);
     }
 }

--- a/database/seeds/CentresSeeder.php
+++ b/database/seeds/CentresSeeder.php
@@ -30,5 +30,8 @@ class CentresSeeder extends Seeder
 
         // Scottish centre
         factory(App\Centre::class)->create(["sponsor_id" => 8]);
+
+        // Social prescribing centre
+        factory(App\Centre::class)->create(['name' => 'Prescribing Centre', 'sponsor_id' => 9]);
     }
 }

--- a/database/seeds/SponsorsSeeder.php
+++ b/database/seeds/SponsorsSeeder.php
@@ -61,7 +61,7 @@ class SponsorsSeeder extends Seeder
         $scottishRulesSponser->evaluations()->saveMany($this->scottishFamilyOverrides());
         $scottishRulesSponser->evaluations()->saveMany($this->veryfiesKids());
 
-        // make an area/sponsor in a different programme
+        // make an area/sponsor in a different programme - should be 9
         factory(App\Sponsor::class)->create([
             'name' => "Social Prescribing Area",
             'shortcode' => "SPA",

--- a/database/seeds/SponsorsSeeder.php
+++ b/database/seeds/SponsorsSeeder.php
@@ -60,6 +60,13 @@ class SponsorsSeeder extends Seeder
         $scottishRulesSponser = factory(App\Sponsor::class)->create(['name' => "Scottish Rules Project"]);
         $scottishRulesSponser->evaluations()->saveMany($this->scottishFamilyOverrides());
         $scottishRulesSponser->evaluations()->saveMany($this->veryfiesKids());
+
+        // make an area/sponsor in a different programme
+        factory(App\Sponsor::class)->create([
+            'name' => "Social Prescribing Area",
+            'shortcode' => "SPA",
+            'programme' => 1 // should be the SP area!
+        ]);
     }
 
     public function veryfiesKids()

--- a/resources/views/store/partials/masthead.blade.php
+++ b/resources/views/store/partials/masthead.blade.php
@@ -18,6 +18,9 @@
         <div class="header-section">
             <ul>
                 <li>User: {{ Auth::user()->name }} </li>
+                @if ( config('app.env') !== 'production' )
+                    <li>Programme: {{ Auth::user()->centre->sponsor->programme_name }}</li>
+                @endif
                 <li>Centre:
                     @if( Auth::user()->centres->count() == 1 )
                         {{ Auth::user()->centre->name }}

--- a/tests/Unit/Models/SponsorModelTest.php
+++ b/tests/Unit/Models/SponsorModelTest.php
@@ -26,11 +26,17 @@ class SponsorModelTest extends TestCase
         // Keeping it simple to make writing test suite less onerous.
         // The default error returned by asserts will be enough.
         $this->assertInstanceOf(Sponsor::class, $s);
-        $this->assertisString($s->name);
+        $this->assertIsString($s->name);
         $this->assertIsString($s->shortcode);
         $this->assertTrue($s->can_tap);
+        $this->assertIsInt($s->programme);
     }
 
+    public function testItCanGetItsProgramName()
+    {
+        $s = $this->sponsor;
+        $this->assertEquals($s->programme_name, config('arc.programmes')[$s->programme]);
+    }
 
     public function testSoftDeleteSponsor()
     {
@@ -49,14 +55,6 @@ class SponsorModelTest extends TestCase
         ]);
         $this->assertCount(10, $this->sponsor->vouchers);
         $this->assertNotEquals($this->sponsor->vouchers, Voucher::all());
-    }
-
-    /** @test */
-    public function itHasExpectedAttributes()
-    {
-        $s = $this->sponsor;
-        $this->assertNotNull($s->name);
-        $this->assertNotNull($s->shortcode);
     }
 
     /** @test */


### PR DESCRIPTION
After this is done, on fetch

`Sponsor::programme` should return an INT
`Sponsor::programme_name` will do a look up on the arc config files and return a name/key

We can navigate to the Sponsor by `Auth::user()->centre->sponsor` if we need to pluck that off to determine a switch. 

At the moment that's fixed. since we don't need to carry much information about Social Prescribing as a _thing_ at this point, a name lookup is sufficient. Should we expand that to needing more properties, we can create a table at a later date.

https://trello.com/c/szywQIcL/1844-a-centre-can-determine-its-mode-vvv-ee