### PR TITLE
1849 remove reasons and notices for SP

### DIFF
--- a/app/Http/Controllers/Store/BundleController.php
+++ b/app/Http/Controllers/Store/BundleController.php
@@ -54,6 +54,7 @@ class BundleController extends Controller
             : null;
 
         $valuation = $registration->getValuation();
+        $programme = Auth::user()->centre->sponsor->programme;
 
         return view('store.manage_vouchers', array_merge(
             $data,
@@ -67,7 +68,8 @@ class BundleController extends Controller
                 "vouchers" => $sorted_bundle,
                 "vouchers_amount" => count($bundle),
                 "entitlement" => $valuation->getEntitlement(),
-                "noticeReasons" => $valuation->getNoticeReasons()
+                "noticeReasons" => $valuation->getNoticeReasons(),
+                "programme" => $programme
             ]
         ));
     }

--- a/app/Http/Controllers/Store/RegistrationController.php
+++ b/app/Http/Controllers/Store/RegistrationController.php
@@ -217,6 +217,7 @@ class RegistrationController extends Controller
 
         $evaluations["creditables"] = $registration->getEvaluator()->getPurposeFilteredEvaluations("credits");
         $evaluations["disqualifiers"] = $registration->getEvaluator()->getPurposeFilteredEvaluations("disqualifiers");
+        $programme = Auth::user()->centre->sponsor->programme;
 
         return view('store.edit_registration', array_merge(
             $data,
@@ -231,7 +232,8 @@ class RegistrationController extends Controller
                 'verifying' => $registration->getEvaluator()->isVerifyingChildren(),
                 'evaluations' => $evaluations,
                 'deferrable' => $deferrable,
-                'can_change_defer' => $can_change_defer
+                'can_change_defer' => $can_change_defer,
+                'programme' => $programme
             ]
         ));
     }

--- a/resources/views/store/edit_registration.blade.php
+++ b/resources/views/store/edit_registration.blade.php
@@ -126,6 +126,10 @@
                             </strong>
                             per week
                         </li>
+                        @if ($programme !==0)
+                            </ul><br>
+                        @endif
+                        @if ($programme === 0)
                         <li>
                             Has
                             <strong>
@@ -162,6 +166,7 @@
                         </li>
                     </ul>
                 </div>
+                        @endif
                 <div>
                     <label for="eligibility-hsbs">
                         Are you receiving Healthy Start or Best Start?
@@ -188,7 +193,9 @@
                         @endforeach
                     </select>
                 </div>
-                @includeWhen(!empty($noticeReasons), 'store.partials.notice_box', ['noticeReasons' => $noticeReasons])
+                @if ($programme === 0)
+                    @includeWhen(!empty($noticeReasons), 'store.partials.notice_box', ['noticeReasons' => $noticeReasons])
+                @endif
                 <button class="long-button submit" type="submit" formnovalidate>Save Changes</button>
                 <button class="long-button"
                         onclick="window.open( '{{ URL::route("store.registration.print", ["registration" => $registration]) }}'); return false">

--- a/resources/views/store/manage_vouchers.blade.php
+++ b/resources/views/store/manage_vouchers.blade.php
@@ -30,7 +30,9 @@
                         </ul>
                     </div>
                 </div>
-                @includeWhen(!empty($noticeReasons), 'store.partials.notice_box', ['noticeReasons' => $noticeReasons])
+                @if ($programme === 0)
+                    @includeWhen(!empty($noticeReasons), 'store.partials.notice_box', ['noticeReasons' => $noticeReasons])
+                @endif
                 <a href="{{ route("store.registration.edit", ['registration' => $registration->id ]) }}" class="link" id='edit-family-link'>
                     <div class="link-button link-button-large">
                         <i class="fa fa-pencil button-icon" aria-hidden="true"></i>Go to edit family


### PR DESCRIPTION
Notices such as "A child is almost primary school age" should not appear for SP in voucher-manager and edit family.
Bullet point "Has 6 children registered (more)" should not not appear for SP in edit family.

$programme has been added for RegistrationController and BundleController so this can be checked in the blades before displaying the correct option. $programme [0] is Standard. 

https://trello.com/c/DZkUtpFd/1849-as-an-sp-user-i-do-not-need-to-see-the-reasons-why-i-am-getting-these-vouchers-vv-e