### PR TITLE
1.14/1855 remove droppers for SP

### DIFF
--- a/app/Http/Controllers/Store/RegistrationController.php
+++ b/app/Http/Controllers/Store/RegistrationController.php
@@ -164,11 +164,13 @@ class RegistrationController extends Controller
         $sponsor = $user->centre->sponsor;
         $evaluator = EvaluatorFactory::make($sponsor->evaluations);
         $verifying = $evaluator->isVerifyingChildren();
+        $programme = Auth::user()->centre->sponsor->programme;
 
         $data = [
             "user_name" => $user->name,
             "centre_name" => ($user->centre) ? $user->centre->name : null,
-            "verifying" => $verifying
+            "verifying" => $verifying,
+            "programme" => $programme
         ];
         return view('store.create_registration', $data);
     }

--- a/app/Http/Requests/StoreNewRegistrationRequest.php
+++ b/app/Http/Requests/StoreNewRegistrationRequest.php
@@ -32,11 +32,13 @@ class StoreNewRegistrationRequest extends FormRequest
         $rules = [
             // MUST be present; MUST be in "yes, on, 1, or true"
             'consent' => 'required|accepted',
-            // MAY be present; MUST be in listed states
+            // SOMETIMES is present; MUST be in listed states
             'eligibility-hsbs' => [
+                'sometimes',
                 Rule::in(config('arc.reg_eligibilities_hsbs')),
             ],
             'eligibility-nrpf' => [
+                'sometimes',
                 Rule::in(config('arc.reg_eligibilities_nrpf')),
             ],
             // MUST be present; MUST be a not-null string

--- a/app/Http/Requests/StoreNewRegistrationRequest.php
+++ b/app/Http/Requests/StoreNewRegistrationRequest.php
@@ -32,13 +32,11 @@ class StoreNewRegistrationRequest extends FormRequest
         $rules = [
             // MUST be present; MUST be in "yes, on, 1, or true"
             'consent' => 'required|accepted',
-            // MUST be present; MUST be in listed states
+            // MAY be present; MUST be in listed states
             'eligibility-hsbs' => [
-                'required',
                 Rule::in(config('arc.reg_eligibilities_hsbs')),
             ],
             'eligibility-nrpf' => [
-                'required',
                 Rule::in(config('arc.reg_eligibilities_nrpf')),
             ],
             // MUST be present; MUST be a not-null string

--- a/app/Http/Requests/StoreUpdateRegistrationRequest.php
+++ b/app/Http/Requests/StoreUpdateRegistrationRequest.php
@@ -48,13 +48,11 @@ class StoreUpdateRegistrationRequest extends FormRequest
             'children.*.dob' => 'required_if:children.*.verified,=,true|date_format:Y-m',
             // MAY be present; MUST be a boolean
             'children.*.verified' => 'boolean',
-            // MUST be present; MUST be in listed states
+            // MAY be present; MUST be in listed states
             'eligibility-hsbs' => [
-                'required',
                 Rule::in(config('arc.reg_eligibilities_hsbs')),
             ],
             'eligibility-nrpf' => [
-                'required',
                 Rule::in(config('arc.reg_eligibilities_nrpf')),
             ],
         ];

--- a/app/Http/Requests/StoreUpdateRegistrationRequest.php
+++ b/app/Http/Requests/StoreUpdateRegistrationRequest.php
@@ -48,11 +48,13 @@ class StoreUpdateRegistrationRequest extends FormRequest
             'children.*.dob' => 'required_if:children.*.verified,=,true|date_format:Y-m',
             // MAY be present; MUST be a boolean
             'children.*.verified' => 'boolean',
-            // MAY be present; MUST be in listed states
+            // SOMETIMES is present; MUST be in listed states
             'eligibility-hsbs' => [
+                'sometimes',
                 Rule::in(config('arc.reg_eligibilities_hsbs')),
             ],
             'eligibility-nrpf' => [
+                'sometimes',
                 Rule::in(config('arc.reg_eligibilities_nrpf')),
             ],
         ];

--- a/resources/views/store/create_registration.blade.php
+++ b/resources/views/store/create_registration.blade.php
@@ -89,6 +89,7 @@
                     <img src="{{ asset('store/assets/info-light.svg') }}" alt="logo">
                     <h2>Other information</h2>
                 </div>
+                @if ($programme === 0)
                 <div>
                     <label for="eligibility-hsbs">
                         Are you receiving Healthy Start or Best Start?
@@ -124,6 +125,7 @@
                         @endforeach
                     </select>
                 </div>
+                @endif
                 <div>
                     <div class="user-control">
                         <input type="checkbox" class="styled-checkbox @if($errors->has('consent'))invalid @endif" id="privacy-statement" name="consent" @if( old('consent') ) checked @endif/>

--- a/resources/views/store/edit_registration.blade.php
+++ b/resources/views/store/edit_registration.blade.php
@@ -166,7 +166,6 @@
                         </li>
                     </ul>
                 </div>
-                        @endif
                 <div>
                     <label for="eligibility-hsbs">
                         Are you receiving Healthy Start or Best Start?
@@ -193,7 +192,6 @@
                         @endforeach
                     </select>
                 </div>
-                @if ($programme === 0)
                     @includeWhen(!empty($noticeReasons), 'store.partials.notice_box', ['noticeReasons' => $noticeReasons])
                 @endif
                 <button class="long-button submit" type="submit" formnovalidate>Save Changes</button>

--- a/tests/Unit/FormRequests/StoreNewRegistrationRequestTest.php
+++ b/tests/Unit/FormRequests/StoreNewRegistrationRequestTest.php
@@ -78,8 +78,8 @@ class StoreNewRegistrationRequestTest extends StoreTestCase
                     'eligibility-nrpf' => 'yes'
                 ]
             ],
-            'requestShouldFailWhenEligibilityIsMissing' => [
-                'passed' => false,
+            'requestCanPassWhenEligibilityIsMissing' => [
+                'passed' => true,
                 'data' => [
                     'consent' => 'on',
                     'carer' => 'A String',

--- a/tests/Unit/FormRequests/StoreNewRegistrationRequestTest.php
+++ b/tests/Unit/FormRequests/StoreNewRegistrationRequestTest.php
@@ -78,6 +78,7 @@ class StoreNewRegistrationRequestTest extends StoreTestCase
                     'eligibility-nrpf' => 'yes'
                 ]
             ],
+            // this can now pass when eligibility is missing due to SP
             'requestCanPassWhenEligibilityIsMissing' => [
                 'passed' => true,
                 'data' => [

--- a/tests/Unit/FormRequests/StoreUpdateRegistrationRequestTest.php
+++ b/tests/Unit/FormRequests/StoreUpdateRegistrationRequestTest.php
@@ -65,6 +65,7 @@ class StoreUpdateRegistrationRequestTest extends StoreTestCase
                     'eligibility-nrpf' => 'yes'
                 ],
             ],
+            // this can now pass when eligibility is missing due to SP
             'requestCanPassWhenEligibilityIsMissing' => [
                 'passed' => true,
                 'data' => [

--- a/tests/Unit/FormRequests/StoreUpdateRegistrationRequestTest.php
+++ b/tests/Unit/FormRequests/StoreUpdateRegistrationRequestTest.php
@@ -65,8 +65,8 @@ class StoreUpdateRegistrationRequestTest extends StoreTestCase
                     'eligibility-nrpf' => 'yes'
                 ],
             ],
-            'requestShouldFailWhenEligibilityIsMissing' => [
-                'passed' => false,
+            'requestCanPassWhenEligibilityIsMissing' => [
+                'passed' => true,
                 'data' => [
                     'pri_carer' => ['A String'],
                 ]


### PR DESCRIPTION
This PR removes the droppers for SP users, plus changes the rules to "sometimes" instead of "required" which then allows null to be recorded in the DB when it's not present (which it won't ever be for SP)

Also changed tests to be able to pass with this missing as the check is no longer necessary.

Full details here: https://trello.com/c/uNKj35dv/1855-should-we-record-nrpf-and-hs-or-bs-for-social-prescribing-vvv-ee