### PR TITLE
1.14/779 hotfix export standard registrations not bringing back all the data

### DIFF
--- a/app/CentreUser.php
+++ b/app/CentreUser.php
@@ -138,7 +138,7 @@ class CentreUser extends Authenticatable
             case "foodmatters_user":
                 $centres = collect(Centre::get()->all());
                 $centres = $centres->filter(function($model) {
-                    return $model->sponsor->programme == 0;
+                    return $model->sponsor->programme === $programme;
                 });
                 break;
             case "centre_user":

--- a/app/CentreUser.php
+++ b/app/CentreUser.php
@@ -137,7 +137,7 @@ class CentreUser extends Authenticatable
         switch ($this->role) {
             case "foodmatters_user":
                 $centres = collect(Centre::get()->all());
-                $centres = $centres->filter(function($model) {
+                $centres = $centres->filter(function($model) use ($programme) {
                     return $model->sponsor->programme === $programme;
                 });
                 break;

--- a/app/CentreUser.php
+++ b/app/CentreUser.php
@@ -136,11 +136,10 @@ class CentreUser extends Authenticatable
         $centres = collect([]);
         switch ($this->role) {
             case "foodmatters_user":
-                $centres = DB::table('centres')
-                    ->leftJoin('sponsors', 'centres.sponsor_id', 'sponsors.id')
-                    ->where('sponsors.programme', $programme)
-                    ->get()
-                ;
+                $centres = collect(Centre::get()->all());
+                $centres = $centres->filter(function($model) {
+                    return $model->sponsor->programme == 0;
+                });
                 break;
             case "centre_user":
                 // If we have one, get our centre's neighbours

--- a/app/Http/Controllers/Store/CentreController.php
+++ b/app/Http/Controllers/Store/CentreController.php
@@ -61,7 +61,7 @@ class CentreController extends Controller
      */
     public function exportRegistrationsSummary(Request $request, Centre $centre)
     {
-        $programme = $request->input('programme', 0);
+        $programme = (int)$request->input('programme', 0);
 
         // Get User
         /** @var CentreUser $user */


### PR DESCRIPTION
Incorrectly merged into 1.14 but this works with the new L9 upgrades, having tested in my local