### PR TITLE
fix: commands exit without crashing the thread

### DIFF
--- a/app/Console/Commands/AddCentre.php
+++ b/app/Console/Commands/AddCentre.php
@@ -78,33 +78,38 @@ class AddCentre extends Command
 
         switch (true) {
             case (!$this->centreUser):
-                exit("Can't find that User.\n");
-                break;
+                $this->error("Can't find that User.");
+                return 1;
             case (!$this->sponsor):
-                exit("Sponsor " .
+                $this->error("Sponsor " .
                     $this->argument('shortcode') .
                     " does not exist, exit without change.\n");
+                return 2;
             case ($this->centre):
-                exit("Centre " .
+                $this->error("Centre " .
                     $this->centre->name .
                     ", " .
                     $this->centre->prefix .
                     " exists, exit without change.\n");
+                return 3;
             case (!in_array($this->argument('preference'), $this->preferences)):
-                exit("The preference " .
+                $this->error("The preference " .
                     $this->argument('preference') .
                     " does not exist, exit without change.\n");
+                return 4;
             default:
                 // Check the centreuser is happy to proceed
                 if (!$this->warnUser()) {
-                    exit("Exit without change.\n");
+                    $this->error("Exit without change.\n");
+                    return 5;
                 };
                 // Log the centreuser in.
                 Auth::login($this->centreUser);
 
                 // Did that work?
                 if (!Auth::check()) {
-                    exit("Failed to login.\n");
+                    $this->error("Failed to login.\n");
+                    return 6;
                 };
 
                 $this->centre = new Centre([
@@ -116,7 +121,7 @@ class AddCentre extends Command
                 $this->centre->sponsor()->associate($this->sponsor);
                 $this->centre->save();
 
-                exit("Done.\n");
+                $this->info("Done.\n");
         }
     }
 

--- a/app/Console/Commands/AddSponsor.php
+++ b/app/Console/Commands/AddSponsor.php
@@ -60,26 +60,29 @@ class AddSponsor extends Command
 
         switch (true) {
             case (!$this->centreUser):
-                exit("Can't find that User.\n");
-                break;
+                $this->error("Can't find that User.\n");
+                return 1;
             case ($this->sponsor):
-                exit("Sponsor " .
+                $this->error("Sponsor " .
                     $this->sponsor->name .
                     ", " .
                     $this->sponsor->shortcode .
                     " exists, exit without change.\n");
+                return 2;
 
             default:
                 // Check the centreuser is happy to proceed
                 if (!$this->warnUser()) {
-                    exit("Exit without change.\n");
+                    $this->error("Exit without change.\n");
+                    return 3;
                 };
                 // Log the centreuser in.
                 Auth::login($this->centreUser);
 
                 // Did that work?
                 if (!Auth::check()) {
-                    exit("Failed to login.\n");
+                    $this->error("Failed to login.\n");
+                    return 4;
                 };
 
                 $this->sponsor = new Sponsor([
@@ -89,7 +92,7 @@ class AddSponsor extends Command
 
                 $this->sponsor->save();
 
-                exit("Done.\n");
+                $this->info("Done.\n");
         }
     }
 

--- a/app/Console/Commands/LegacyImport.php
+++ b/app/Console/Commands/LegacyImport.php
@@ -58,17 +58,18 @@ class LegacyImport extends Command
 
         switch (true) {
             case (!$this->authUser):
-                exit("Can't find the AdminUser");
-                break;
+                $this->error("Can't find the AdminUser");
+                return 1;
             case (!$this->sponsor):
-                exit("Can't find the Sponsor");
-                break;
+                $this->error("Can't find the Sponsor");
+                return 2;
             case (empty($this->codes)):
-                exit("There are no codes");
-                break;
+                $this->error("There are no codes");
+                return 3;
             default:
                 if (!$this->warnUser()) {
-                    exit("Failed to log in\n");
+                    $this->error("Failed to log in\n");
+                    return 4;
                 };
                 Auth::login($this->authUser);
                 $bar = $this->output->createProgressBar(count($this->codes));

--- a/app/Console/Commands/MvlExport.php
+++ b/app/Console/Commands/MvlExport.php
@@ -59,9 +59,45 @@ class MvlExport extends Command
     /**
      * Execute the console command.
      */
-    public function handle(): void
+    public function handle(): int
     {
-        $this->initSettings();
+        $from = $this->option('from');
+        if ($from) {
+            try {
+                $this->startDate = Carbon::createFromFormat('d/m/Y', $from, 'UTC');
+            } catch (InvalidFormatException $exception) {
+                // Not a date
+                $this->error("From date was not a valid date: " . $from);
+                return 1;
+            }
+        } else {
+            // We were going to start this financial year
+            // $this->startDate = $this->getStartOfThisFinancialYear()->format('d/m/Y');
+            $this->startDate = Carbon::createFromFormat('d/m/Y', "01/01/1970", 'UTC');
+        }
+
+        $to = $this->option('to');
+        if ($to) {
+            try {
+                $this->endDate = Carbon::createFromFormat('d/m/Y', $to, 'UTC');
+            } catch (InvalidFormatException $exception) {
+                // Not a date
+                $this->error("To date was not a valid date: " . $to);
+                return 2;
+            }
+        } else {
+            // We were going to use till now
+            // $this->endDate = Carbon::now()->format('d/m/Y');
+            $this->endDate = Carbon::createFromFormat('d/m/Y', "31/08/2023", 'UTC');
+        }
+
+        $chunkSize = $this->option("chunk-size");
+        if ($chunkSize) {
+            $this->chunkSize = intval($chunkSize);
+            if ($this->chunkSize === 0) {
+                $this->error("Chunk size does not seem to be a valid int: " . $chunkSize);
+            }
+        }
 
         $this->info(
             sprintf(
@@ -123,50 +159,5 @@ class MvlExport extends Command
 
             $offset += $this->chunkSize;
         }
-    }
-
-    /**
-     * @return void
-     */
-    public function initSettings(): void
-    {
-        $from = $this->option('from');
-        if ($from) {
-            try {
-                $this->startDate = Carbon::createFromFormat('d/m/Y', $from, 'UTC');
-            } catch (InvalidFormatException $exception) {
-                // Not a date
-                $this->error("From date was not a valid date: " . $from);
-                exit(1);
-            }
-        } else {
-            // We were going to start this financial year
-            // $this->startDate = $this->getStartOfThisFinancialYear()->format('d/m/Y');
-            $this->startDate = Carbon::createFromFormat('d/m/Y', "01/01/1970", 'UTC');
-        }
-
-        $to = $this->option('to');
-        if ($to) {
-            try {
-                $this->endDate = Carbon::createFromFormat('d/m/Y', $to, 'UTC');
-            } catch (InvalidFormatException $exception) {
-                // Not a date
-                $this->error("To date was not a valid date: " . $to);
-                exit(1);
-            }
-        } else {
-            // We were going to use till now
-            // $this->endDate = Carbon::now()->format('d/m/Y');
-            $this->endDate = Carbon::createFromFormat('d/m/Y', "31/08/2023", 'UTC');
-        }
-
-        $chunkSize = $this->option("chunk-size");
-        if ($chunkSize) {
-            $this->chunkSize = intval($chunkSize);
-            if ($this->chunkSize === 0) {
-                $this->error("Chunk size does not seem to be a valid int: " . $chunkSize);
-            }
-        }
-
     }
 }


### PR DESCRIPTION
I was writing tests for the commands (currently <5% coverage) and most of the commands use `exit(1)` on error. This crashes the php thread.

Was that by design?