### PR TITLE
fix: orWhereColumn

### DIFF
--- a/app/Registration.php
+++ b/app/Registration.php
@@ -189,7 +189,7 @@ class Registration extends Model implements IEvaluee
     {
         return $query->whereHas('family', function ($q) {
             $q->whereNull('leaving_on');
-            $q->orWhere('rejoin_on', '>', 'leaving_on');
+            $q->orWhereColumn('rejoin_on', '>', 'leaving_on');
         });
     }
 }


### PR DESCRIPTION
https://trello.com/c/4wP7BACi/1014-HOTFIX-removed-families-still-on-collection-sheet

So, currently we're not comparing the 'rejoin_on and 'leaving_on' columns... wre're comparing the string "leavin_on" to the `rejoin_on` column :facepalm: 

we should use `orWhereColumn()` to compare column values, not `orWhere`