### PR TITLE
2053 enable re adding of deleted workers ee v

### DIFF
--- a/app/Http/Controllers/Service/Admin/CentreUsersController.php
+++ b/app/Http/Controllers/Service/Admin/CentreUsersController.php
@@ -9,7 +9,6 @@ use App\Http\Requests\AdminIndexCentreUsersRequest;
 use App\Http\Requests\AdminNewCentreUserRequest;
 use App\Http\Requests\AdminUpdateCentreUserRequest;
 use App\Sponsor;
-use Carbon\Carbon;
 use DB;
 use Debugbar;
 use Exception;
@@ -42,12 +41,12 @@ class CentreUsersController extends Controller
             'name' => 'name',
             'homeCentreArea' => 'homeCentre.sponsor.name',
             'homeCentre' => 'homeCentre.name',
-            default => function ($item) {
+            default => static function ($item) {
                 $homeCentre = $item->homeCentre;
-                return $homeCentre->sponsor->name . '#' . $homeCentre->name . '#' . $item->name;
+                return $homeCentre?->sponsor?->name . '#' . $homeCentre?->name . '#' . $item->name;
             },
         };
-        $workers = CentreUser::get()->sortBy($sorter, SORT_REGULAR, ($direction === 'desc'));
+        $workers = CentreUser::withTrashed()->get()->sortBy($sorter, SORT_REGULAR, ($direction === 'desc'));
 
         return view('service.centreusers.index', compact('workers'));
     }

--- a/app/Http/Controllers/Service/Admin/CentreUsersController.php
+++ b/app/Http/Controllers/Service/Admin/CentreUsersController.php
@@ -283,7 +283,7 @@ class CentreUsersController extends Controller
         } else {
             $centreUser->restore();
         }
-        return redirect()->route('admin.centreusers.index')
+        return redirect()->route('admin.centreusers.edit', ['id' => $centreUser->id])
             ->with('message', 'Worker ' . $name . ' updated');
     }
 }

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -412,3 +412,7 @@ tr.disabled {
   color: gray;
   font-style: italic;
 }
+
+button.remove {
+  background-color: #d2232a;
+}

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -407,3 +407,8 @@ span.user-array {
   width: 40px;
   height: 40px;
 }
+
+tr.disabled {
+  color: gray;
+  font-style: italic;
+}

--- a/resources/views/service/centreusers/edit.blade.php
+++ b/resources/views/service/centreusers/edit.blade.php
@@ -9,6 +9,10 @@
 
         <p>Use the form below to amend a Children's Centre Worker's details.</p>
 
+        @if($worker->deleted_at)
+            <h2>This worker is <i>disabled</i></h2>
+        @endif
+
         <form role="form" class="styled-form" method="POST"
             action="{{ route('admin.centreusers.update', ['id' => $worker->id]) }}">
             {!! method_field('PUT') !!}

--- a/resources/views/service/centreusers/edit.blade.php
+++ b/resources/views/service/centreusers/edit.blade.php
@@ -77,7 +77,7 @@
         </form>
         <form role="form" id="toggleForm" class="styled-form" method="GET" action="{{ route('admin.centreusers.toggle', ['id' => $worker->id]) }}">
             {!! csrf_field() !!}
-            <button type="submit" id="toggleWorker">@empty($worker->deleted_at)Disable @else Enable @endif worker</button>
+            <button type="submit" id="toggleWorker">@empty($worker->deleted_at)Disable worker @else Enable worker @endif</button>
         </form>
         @if($worker->deleted_at)
         <form role="form" id="deleteForm" class="styled-form" method="GET"

--- a/resources/views/service/centreusers/edit.blade.php
+++ b/resources/views/service/centreusers/edit.blade.php
@@ -67,13 +67,21 @@
                     </div>
                 </div>
             </div>
-            <button type="submit" id="updateWorker">Update worker</button>
+            @empty($worker->deleted_at)
+                <button type="submit" id="updateWorker">Update worker</button>
+            @endempty
         </form>
+        <form role="form" id="toggleForm" class="styled-form" method="GET" action="{{ route('admin.centreusers.toggle', ['id' => $worker->id]) }}">
+            {!! csrf_field() !!}
+            <button type="submit" id="toggleWorker">@empty($worker->deleted_at)Disable @else Enable @endif worker</button>
+        </form>
+        @if($worker->deleted_at)
         <form role="form" id="deleteForm" class="styled-form" method="GET"
             action="{{ route('admin.centreusers.delete', ['id' => $worker->id]) }}">
             {!! csrf_field() !!}
-          <button type="submit" id="deleteWorker">Delete worker</button>
+          <button type="submit" id="deleteWorker" class="remove">Delete worker</button>
         </form>
+        @endif
         <script>
             function buildCheckboxes() {
                 // Setup data for checkboxes
@@ -166,7 +174,7 @@
                 $('#deleteWorker').on('click', function (evt) {
                   evt.preventDefault();
                   var deleteForm = document.getElementById('deleteForm');
-                  var areYouSure = confirm('Are you sure you want to delete this worker account?');
+                  var areYouSure = confirm('Are you sure you want to PERMANENTLY delete this worker account?');
                   if (areYouSure === true) {
                     deleteForm.submit();
                   };

--- a/resources/views/service/centreusers/index.blade.php
+++ b/resources/views/service/centreusers/index.blade.php
@@ -26,17 +26,17 @@
             </thead>
             <tbody>
                 @foreach ($workers as $worker)
-                <tr>
+                <tr @class(['disabled' => $worker->deleted_at !== null])">
                     <td>{{ $worker->name }}</td>
                     <td>{{ $worker->email }}</td>
-                    <td> {{ $worker->homeCentre->sponsor->name }}</td>
-                    <td>{{ $worker->homeCentre->name }}</td>
+                    <td> {{ $worker->homeCentre?->sponsor->name }}</td>
+                    <td>{{ $worker->homeCentre?->name }}</td>
                     <td>
                         <ul class="table-list">
                             @foreach ($worker->centres as $centre)
-                            @if ($centre->id !== $worker->homeCentre->id)
-                            <li>{{ $centre->name }}</li>
-                            @endif
+                                @if ($centre->id !== $worker->homeCentre?->id)
+                                    <li>{{ $centre->name }}</li>
+                                @endif
                             @endforeach
                         </ul>
                     </td>

--- a/routes/service.php
+++ b/routes/service.php
@@ -115,6 +115,12 @@ Route::group(['middleware' => 'auth:admin'], function () {
         'as' => 'admin.centreusers.download',
         'uses' => 'Admin\CentreUsersController@download',
     ]);
+
+    Route::get('workers/{id}/toggle', [
+        'as' => 'admin.centreusers.toggle',
+        'uses' => 'Admin\CentreUsersController@toggle',
+    ])->where('id', '^[0-9]+$');
+
     Route::get('workers/{id}/delete', [
         'as' => 'admin.centreusers.delete',
         'uses' => 'Admin\CentreUsersController@delete',

--- a/tests/Unit/Controllers/Service/Admin/CentreUserControllerTest.php
+++ b/tests/Unit/Controllers/Service/Admin/CentreUserControllerTest.php
@@ -13,17 +13,13 @@ class CentreUserControllerTest extends StoreTestCase
 {
     use RefreshDatabase;
 
-    /** @var AdminUser $adminUser */
-    private $adminUser;
+    private AdminUser $adminUser;
 
-    /** @var Centre $centre */
-    private $centre;
+    private Centre $centre;
 
-    /** @var Collection $altCentres */
-    private $altCentres;
+    private Collection $altCentres;
 
-    /** @var array $data */
-    private $data;
+    private array $data;
 
     public function setUp(): void
     {
@@ -39,8 +35,7 @@ class CentreUserControllerTest extends StoreTestCase
         ];
     }
 
-    /** @test */
-    public function testICanStoreACentreUser()
+    public function testICanStoreACentreUser(): void
     {
         $this->actingAs($this->adminUser, 'admin')
             ->post(
@@ -62,8 +57,7 @@ class CentreUserControllerTest extends StoreTestCase
         $this->assertEquals($this->data['worker_centre'], $cu->homeCentre->id);
     }
 
-    /** @test */
-    public function testItCanUpdateACentreUser()
+    public function testItCanUpdateACentreUser(): void
     {
         // Make a CentreUser from the data with 1 homeCentre.
         $cu = factory(CentreUser::class)->create([
@@ -117,8 +111,7 @@ class CentreUserControllerTest extends StoreTestCase
         $this->assertEquals($this->data['worker_centre'], $cu->homeCentre->id);
     }
 
-    /** @test */
-    public function testItCanDeleteACentreUser()
+    public function testItCanDeleteACentreUser(): void
     {
         $cu = factory(CentreUser::class)->create([
             'name' => "testman",
@@ -147,8 +140,7 @@ class CentreUserControllerTest extends StoreTestCase
         ;
     }
 
-    /** @test */
-    public function testICannotSeeDeletedCentreUsers()
+    public function testICannotSeeDeletedCentreUsers(): void
     {
         $cu = factory(CentreUser::class)->create([
             'name' => "testman",


### PR DESCRIPTION
https://trello.com/c/ZPfZcmIc/2053-enable-re-adding-of-deleted-workers-ee-v
- Adds an enable/disable user toggle that uses the existing soft deletes to deal with deactivating a user without altering any relations.
- Adds a force delete button enabled after the user is toggled disabled, so an admin can actually, properly remove the user.