### PR TITLE
2199 fandv prescrptions not showing ethnicity or mainlanguage

### DIFF
--- a/app/Http/Controllers/Store/CentreController.php
+++ b/app/Http/Controllers/Store/CentreController.php
@@ -176,14 +176,23 @@ class CentreController extends Controller
     protected function getRegistrations(array $centreIds): Collection
     {
         return Registration::withFullFamily()->whereIn('centre_id', $centreIds)->with([
-            'centre',
-            'centre.sponsor',
+            'centre:id,name,sponsor_id',
+            'centre.sponsor:id,name',
+            'lastBundle:id,registration_id,disbursed_at',
+        ])->select([
+            'id',
+            'centre_id',
+            'family_id',
+            'created_at',
+            'eligibility_hsbs',
+            'eligibility_nrpf',
+            'eligible_from',
         ])->get();
     }
 
     protected function buildBaseRow(Registration $registration): array
     {
-        $lastCollection = $this->getLastCollectionDate($registration);
+        $lastCollection = $registration->lastBundle?->disbursed_at;
         $label = $this->labels[$this->labelType];
 
         return [
@@ -195,15 +204,6 @@ class CentreController extends Controller
             'Last Collection' => $lastCollection ? $lastCollection->format($this->dateFormats['lastCollection']) : null,
             'Active' => $registration->isActive() ? 'true' : 'false',
         ];
-    }
-
-    protected function getLastCollectionDate(Registration $registration)
-    {
-        $lastCollection = $registration->bundles()->whereNotNull('disbursed_at')->orderBy(
-            'disbursed_at',
-            'desc'
-        )->first();
-        return $lastCollection?->disbursed_at;
     }
 
     protected function processChildren(Registration $registration): array

--- a/app/Http/Controllers/Store/CentreController.php
+++ b/app/Http/Controllers/Store/CentreController.php
@@ -286,6 +286,7 @@ class CentreController extends Controller
                 $fields = [
                     ...$fields,
                     'Eligible Household Members' => $childrenData['eligible_count'],
+                    ...$this->getCarerDetails($registration),
                 ];
                 break;
             default:
@@ -324,7 +325,7 @@ class CentreController extends Controller
         $language = 'not answered';
         $otherLanguage = '';
 
-        if ($carer && $carer->language !== null) {
+        if ($carer && ($carer->language !== null)) {
             $language = ($carer->language === 'english') ? 'english' : 'other';
             $otherLanguage = ($language === 'other') ? strtolower($carer->language) : '';
         }

--- a/app/Registration.php
+++ b/app/Registration.php
@@ -11,6 +11,7 @@ use Eloquent;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 
 /**
  * @mixin Eloquent
@@ -191,5 +192,12 @@ class Registration extends Model implements IEvaluee
             $q->whereNull('leaving_on');
             $q->orWhereColumn('rejoin_on', '>', 'leaving_on');
         });
+    }
+
+    public function lastBundle(): HasOne
+    {
+        return $this->hasOne(Bundle::class)
+            ->whereNotNull('disbursed_at')
+            ->latest('disbursed_at');
     }
 }


### PR DESCRIPTION
https://trello.com/c/um3RMYkE/2199-fandv-prescrptions-not-showing-ethnicity-or-mainlanguage

We permit certain centre users to download  a list of the families with a bunch of collated and calculated data (entitlement, last pickup, number of kids, etc).
 
Code was added a while ago to get some demographics fields for the standard programme
They wanted it added to the fruit and veg prescription (via GPs) programme.