### PR TITLE
1.20/2189-bug-permenently-deleting-a-centre-user-ee-vv

### DIFF
--- a/app/CentreUser.php
+++ b/app/CentreUser.php
@@ -2,15 +2,18 @@
 
 namespace App;
 
+use App\Notifications\StorePasswordResetNotification;
+use App\Traits\Retirable;
 use Eloquent;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\belongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Notifications\Notifiable;
 use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Collection;
-use App\Notifications\StorePasswordResetNotification;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
 
 /**
  * @mixin Eloquent
@@ -27,6 +30,7 @@ class CentreUser extends Authenticatable
 {
     use Notifiable;
     use SoftDeletes;
+    use Retirable;
 
     protected string $guard = 'store';
 
@@ -36,7 +40,11 @@ class CentreUser extends Authenticatable
      * @var array
      */
     protected $fillable = [
-        'name', 'email', 'password', 'role', 'downloader',
+        'name',
+        'email',
+        'password',
+        'role',
+        'downloader',
     ];
 
     /**
@@ -45,7 +53,7 @@ class CentreUser extends Authenticatable
      * @var array
      */
     protected $appends = [
-        'homeCentre'
+        'homeCentre',
     ];
 
     /**
@@ -54,7 +62,8 @@ class CentreUser extends Authenticatable
      * @var array
      */
     protected $hidden = [
-        'password', 'remember_token',
+        'password',
+        'remember_token',
     ];
 
     /**
@@ -67,6 +76,15 @@ class CentreUser extends Authenticatable
         'deleted_at' => 'datetime',
     ];
 
+    protected function retirableFields(): array
+    {
+        return [
+            'name' => '[User Retired]',
+            'email' => 'retired_' . Str::uuid() . '@retired.invalid',
+            'password' => Hash::make(Str::uuid()),
+            'remember_token' => null,
+        ];
+    }
     /**
      * Get the Notes that belong to this CentreUser
      */
@@ -152,7 +170,7 @@ class CentreUser extends Authenticatable
     /**
      * Send the password reset notification.
      *
-     * @param  string  $token
+     * @param string $token
      */
     public function sendPasswordResetNotification($token): void
     {

--- a/app/Http/Controllers/Service/Admin/CentreUsersController.php
+++ b/app/Http/Controllers/Service/Admin/CentreUsersController.php
@@ -23,16 +23,13 @@ use League\Csv\CannotInsertRecord;
 use Log;
 use Ramsey\Uuid\Uuid;
 use Throwable;
-use function PHPUnit\Framework\isNan;
 
 class CentreUsersController extends Controller
 {
     /**
      * Display a listing of Workers.
-     * @param AdminIndexCentreUsersRequest $request
-     * @return Application|Factory|View
      */
-    public function index(AdminIndexCentreUsersRequest $request): View|Factory|Application
+    public function index(AdminIndexCentreUsersRequest $request): Factory|View
     {
         // fetch query params from request
         $field = $request->input('orderBy');
@@ -47,7 +44,7 @@ class CentreUsersController extends Controller
                 return $homeCentre?->sponsor?->name . '#' . $homeCentre?->name . '#' . $item->name;
             },
         };
-        $workers = CentreUser::withTrashed()->get()->sortBy($sorter, SORT_REGULAR, ($direction === 'desc'));
+        $workers = CentreUser::withTrashed()->active()->get()->sortBy($sorter, SORT_REGULAR, ($direction === 'desc'));
 
         return view('service.centreusers.index', compact('workers'));
     }
@@ -101,12 +98,9 @@ class CentreUsersController extends Controller
 
     /**
      * Update a CentreUser from a form
-     * @param AdminUpdateCentreUserRequest $request
-     * @param $id
-     * @return RedirectResponse
      * @throws Throwable
      */
-    public function update(AdminUpdateCentreUserRequest $request, $id)
+    public function update(AdminUpdateCentreUserRequest $request, $id): RedirectResponse
     {
         try {
             $centreUser = DB::transaction(function () use ($request, $id) {
@@ -140,11 +134,8 @@ class CentreUsersController extends Controller
 
     /**
      * Code deduplication;
-     * @param Request $request
-     * @param CentreUser $cu
-     * @return array
      */
-    private function syncCentres(Request $request, CentreUser $cu): array
+    private function syncCentres(Request $request, CentreUser $cu): void
     {
         // Set Home Centre
         $homeCentre_id = $request->input('worker_centre');
@@ -162,13 +153,11 @@ class CentreUsersController extends Controller
             }
         }
         // Sync them setting pivots.
-        return $cu->centres()->sync($centre_ids);
+        $cu->centres()->sync($centre_ids);
     }
 
     /**
      * Create a CentreUser from a form
-     * @param AdminNewCentreUserRequest $request
-     * @return RedirectResponse
      * @throws Throwable
      */
     public function store(AdminNewCentreUserRequest $request): RedirectResponse
@@ -196,12 +185,13 @@ class CentreUsersController extends Controller
             // Throw it back to the user
             return redirect()->route('admin.centreusers.create')->withErrors('Creation failed - DB Error.');
         }
-        return redirect()->route('admin.centreusers.index')->with('message',
-            'Worker ' . $centreUser->name . ' created');
+        return redirect()->route('admin.centreusers.index')->with(
+            'message',
+            'Worker ' . $centreUser->name . ' created'
+        );
     }
 
     /**
-     * @return void
      * @throws CannotInsertRecord
      */
     public function download(): void
@@ -253,20 +243,18 @@ class CentreUsersController extends Controller
 
     /**
      * Handle deleting a centre user
-     * @param int $id
-     * @return RedirectResponse
      */
-    public function delete(int $id): RedirectResponse
+    public function retire(int $id): RedirectResponse
     {
         // must be disabled to delete
         $centreUser = CentreUser::onlyTrashed()->findOrFail($id);
         $name = $centreUser->name;
-        // remove any connections
-        $centreUser->centre->centreUsers()->detach($id);
+
         // boot them
-        $centreUser->forceDelete();
+        $centreUser->retire();
+
         return redirect()->route('admin.centreusers.index')
-            ->with('message', 'Worker ' . $name . ' deleted');
+            ->with('message', 'Worker ' . $name . ' retired');
     }
 
     /**

--- a/app/Traits/Retirable.php
+++ b/app/Traits/Retirable.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Traits;
+
+use DomainException;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use LogicException;
+
+trait Retirable
+{
+    /**
+     * Magically invoked
+     */
+    public static function bootRetirable(): void
+    {
+        if (!in_array(SoftDeletes::class, class_uses_recursive(static::class), true)) {
+            throw new LogicException(
+                static::class . ' must use SoftDeletes to use the Retirable trait.'
+            );
+        }
+
+        // Cancel any restore attempt on a retired model.
+        static::restoring(static function ($model) {
+            if ($model->retired_at !== null) {
+                throw new DomainException(
+                    "Retired " . get_class($model) . " [{$model->id}] cannot be restored."
+                );
+            }
+        });
+    }
+
+    /**
+     * Magically invoked - Adds retired_at to the model
+     */
+    public function initializeRetirable(): void
+    {
+        $this->casts['retired_at'] = 'datetime';
+    }
+
+    /**
+     * Map of field => retirement value.
+     * Override in the consuming class to match its DDL constraints.
+     */
+    protected function retirableFields(): array
+    {
+        return [
+            'remember_token' => null,
+        ];
+    }
+
+    public function retire(): void
+    {
+        if ($this->retired_at !== null) {
+            return;
+        }
+
+        $this->forceFill(
+            array_merge($this->retirableFields(), ['retired_at' => now()])
+        )->save();
+
+        $this->delete();
+    }
+
+    public function isRetired(): bool
+    {
+        return $this->retired_at !== null;
+    }
+
+    public function scopeRetired($query)
+    {
+        return $query->withTrashed()->whereNotNull('retired_at');
+    }
+
+    // Not trashed or retired
+    public function scopeActive($query)
+    {
+        return $query->whereNull('retired_at');
+    }
+}

--- a/app/Traits/Retirable.php
+++ b/app/Traits/Retirable.php
@@ -58,6 +58,7 @@ trait Retirable
             array_merge($this->retirableFields(), ['retired_at' => now()])
         )->save();
 
+        // if we're not already soft deleted, do that too.
         $this->delete();
     }
 

--- a/app/Traits/Retirable.php
+++ b/app/Traits/Retirable.php
@@ -54,12 +54,15 @@ trait Retirable
             return;
         }
 
+        if (!$this->trashed()) {
+            throw new DomainException(
+                get_class($this) . " [$this->id] must be disabled before it can be retired."
+            );
+        }
+
         $this->forceFill(
             array_merge($this->retirableFields(), ['retired_at' => now()])
         )->save();
-
-        // if we're not already soft deleted, do that too.
-        $this->delete();
     }
 
     public function isRetired(): bool

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -63,6 +63,8 @@ $factory->define(App\CentreUser::class, function (Faker\Generator $faker) {
  * Relations (notes, centres) are preserved on the underlying row.
  */
 $factory->afterCreatingState(App\CentreUser::class, 'retired', function ($centreUser) {
+    // retired centres must be soft deleted first
+    $centreUser->delete();
     $centreUser->retire();
 });
 

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -58,6 +58,15 @@ $factory->define(App\CentreUser::class, function (Faker\Generator $faker) {
 });
 
 /**
+ * CentreUser in the retired state.
+ * PII is wiped, retired_at is set, and the model is soft-deleted.
+ * Relations (notes, centres) are preserved on the underlying row.
+ */
+$factory->afterCreatingState(App\CentreUser::class, 'retired', function ($centreUser) {
+    $centreUser->retire();
+});
+
+/**
  * CentreUser who can Download.
  */
 $factory->state(App\CentreUser::class, 'withDownloader', function ($faker) use ($factory) {

--- a/database/migrations/2026_04_03_163930_add_retired_at_to_centre_users.php
+++ b/database/migrations/2026_04_03_163930_add_retired_at_to_centre_users.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('centre_users', static function (Blueprint $table) {
+            $table->datetime('retired_at')->after('deleted_at')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('centre_users', static function (Blueprint $table) {
+            $table->dropColumn(['retired_at']);
+        });
+    }
+};

--- a/database/seeders/CentreUsersSeeder.php
+++ b/database/seeders/CentreUsersSeeder.php
@@ -107,14 +107,12 @@ class CentreUsersSeeder extends Seeder
      */
     private function seedRetiredUsers(): void
     {
-        factory(CentreUser::class, 2)
+        factory(CentreUser::class, 2)->state('retired')
             ->create()
             ->each(function (CentreUser $centreUser) {
                 $centre = Centre::inRandomOrder()->first()
                     ?? factory(Centre::class)->create();
-
                 $centreUser->centres()->attach($centre->id, ['homeCentre' => true]);
-                $centreUser->retire();
             });
     }
 

--- a/database/seeders/CentreUsersSeeder.php
+++ b/database/seeders/CentreUsersSeeder.php
@@ -1,117 +1,143 @@
 <?php
+
 namespace Database\Seeders;
 
 use App\Centre;
 use App\CentreUser;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Hash;
 
 class CentreUsersSeeder extends Seeder
 {
     /**
-     * Run the database seeds.
-     *
-     * @return void
+     * Password shared by all named seed users.
      */
-    public function run()
+    private string $defaultPassword;
+
+    public function run(): void
     {
-        // 1 specific user in the first centre
-        $user1 = factory(CentreUser::class)->create([
-            "name"  => "ARC CC User",
-            "email" => "arc+ccuser@neontribe.co.uk",
-            "password" => bcrypt('store_pass'),
-            "role" => "centre_user",
+        $this->defaultPassword = Hash::make('store_pass');
+
+        $this->seedCcUser();
+        $this->seedNamedUsers();
+        $this->seedRandomUsers();
+        $this->seedDeletedUsers();
+        $this->seedRetiredUsers();
+    }
+
+    /**
+     * CC user requires additional centre setup so is handled separately.
+     */
+    private function seedCcUser(): void
+    {
+        $user = $this->createAndAttach(
+            attributes: ['name' => 'ARC CC User', 'email' => 'arc+ccuser@exmaple.com', 'role' => 'centre_user'],
+            centreId: 1,
+            isHome: true
+        );
+
+        // Two extra centres sharing the same sponsor, attached as non-home.
+        $sponsorId = $user->centres()->first()->sponsor->id;
+        $localCentres = factory(Centre::class, 2)->create(['sponsor_id' => $sponsorId]);
+
+        $user->centres()->attach([
+            $localCentres[0]->id => ['homeCentre' => false],
+            $localCentres[1]->id => ['homeCentre' => false],
         ]);
+    }
 
-        // Attach an initial centre
-        $user1->centres()->attach([
-            1 => ['homeCentre' => true]
-        ]);
+    /**
+     * Named users with fixed centre assignments.
+     * Each entry: [ state, name, email, centreId | centreName ]
+     */
+    private function seedNamedUsers(): void
+    {
+        $users = [
+            ['FMUser', 'ARC FM User', 'arc+fmuser@exmaple.com', 1],
+            ['FMUser', 'ARC fmuser2', 'arc+fmuser2@exmaple.com', 2],
+            ['', 'prescribing user', 'arc+spuser@exmaple.com', 'Prescribing Centre'],
+            ['', 'Scottish user', 'arc+scuser@exmaple.com', 8],
+            ['', 'Southwark user', 'arc+swuser@exmaple.com', 6],
+            ['', 'Tower Hamlet SP user', 'arc+thuser@exmaple.com', 10],
+            ['', 'Lambeth SP user', 'arc+lambethuser@exmaple.com', 11],
+        ];
 
-        // Get the first centre's sponsor and make two more centres with the same sponsor
-        $sponsor_id = $user1->centres()->first()->sponsor->id;
+        foreach ($users as [$state, $name, $email, $centre]) {
+            $centreId = is_int($centre)
+                ? $centre
+                : Centre::where('name', $centre)->first()->id;
 
-        $local_centres = factory(Centre::class, 2)->create(['sponsor_id' => $sponsor_id]);
+            $this->createAndAttach(
+                attributes: ['name' => $name, 'email' => $email],
+                centreId: $centreId,
+                state: $state
+            );
+        }
+    }
 
-        // Attach the extra centres
-        $user1->centres()->attach([
-            $local_centres[0]->id  => ['homeCentre' => false],
-            $local_centres[1]->id  => ['homeCentre' => false],
-        ]);
-
-        $user2 = factory(CentreUser::class)->state('FMUser')->create([
-            "name"  => "ARC FM User",
-            "email" => "arc+fmuser@neontribe.co.uk",
-            "password" => bcrypt('store_pass'),
-        ]);
-        $user2->centres()->attach(1, ['homeCentre' => true]);
-
-        // ARC admin is an fmuser in centre 2, which has individual forms on the dashboard.
-        $user3 = factory(CentreUser::class)->state('FMUser')->create([
-            "name"  => "ARC fmuser2",
-            "email" => "arc+fmuser2@neontribe.co.uk",
-            "password" => bcrypt('store_pass'),
-        ]);
-        $user3->centres()->attach(2, ['homeCentre' => true]);
-
-        // 4 faked users associated with random Centres
+    /**
+     * Four faked users each attached to a random existing centre.
+     */
+    private function seedRandomUsers(): void
+    {
         factory(CentreUser::class, 4)
             ->create()
-            ->each(function ($centreUser) {
-                $centres  = Centre::get();
-                if ($centres->count() > 0) {
-                    // Pick a random Centre
-                    $centre = $centres[random_int(0, $centres->count()-1)];
-                } else {
-                    // There should be at least one Centre
-                    $centre = factory(Centre::class)->create();
-                }
+            ->each(function (CentreUser $centreUser) {
+                $centre = Centre::inRandomOrder()->first()
+                    ?? factory(Centre::class)->create();
+
                 $centreUser->centres()->attach($centre->id, ['homeCentre' => true]);
             });
+    }
 
-        // 2 deleted users
-        $deletedUsers = factory(CentreUser::class, 2)->create([
-            "deleted_at"  => date("Y-m-d H:i:s"),
-        ]);
+    /**
+     * Two soft-deleted users.
+     */
+    private function seedDeletedUsers(): void
+    {
+        factory(CentreUser::class, 2)->create(['deleted_at' => now()]);
+    }
 
-        // an SP user for testing
-        $socialPrescriber = factory(CentreUser::class)->create([
-            'name' => 'prescribing user',
-            'email' => 'arc+spuser@neontribe.co.uk',
-            "password" => bcrypt('store_pass'),
-        ]);
-        $spcId = Centre::where('name', 'Prescribing Centre')->first()->id;
-        $socialPrescriber->centres()->attach($spcId, ["homeCentre" => true]);
+    /**
+     * Two retired users, each attached to a random centre before retirement.
+     *
+     * Centre relations are preserved on the underlying row after retirement.
+     * Retirement is called directly rather than via the factory state because
+     * the centre must be attached first — retire() must run last.
+     */
+    private function seedRetiredUsers(): void
+    {
+        factory(CentreUser::class, 2)
+            ->create()
+            ->each(function (CentreUser $centreUser) {
+                $centre = Centre::inRandomOrder()->first()
+                    ?? factory(Centre::class)->create();
 
-        // Scottish user for testing
-        $scottishUser = factory(CentreUser::class)->create([
-            'name' => 'Scottish user',
-            'email' => 'arc+scuser@neontribe.co.uk',
-            'password' => bcrypt('store_pass'),
-        ]);
-        $scottishUser->centres()->attach(8, ['homeCentre' => true]);
+                $centreUser->centres()->attach($centre->id, ['homeCentre' => true]);
+                $centreUser->retire();
+            });
+    }
 
-        // Southwark user for testing
-        $southwarkUser = factory(CentreUser::class)->create([
-            'name' => 'Southwark user',
-            'email' => 'arc+swuser@neontribe.co.uk',
-            'password' => bcrypt('store_pass'),
-        ]);
-        $southwarkUser->centres()->attach(6, ['homeCentre' => true]);
+    /**
+     * Create a CentreUser and attach them to a centre in one step.
+     */
+    private function createAndAttach(
+        array $attributes,
+        int $centreId,
+        bool $isHome = true,
+        string $state = ''
+    ): CentreUser {
+        $attributes['password'] ??= $this->defaultPassword;
 
-		// Tower Hamlet SP user for testing
-		$towerHamletUser = factory(CentreUser::class)->create([
-			'name' => 'Tower Hamlet SP user',
-			'email' => 'arc+thuser@neontribe.co.uk',
-			'password' => bcrypt('store_pass'),
-		]);
-		$towerHamletUser->centres()->attach(10, ['homeCentre' => true]);
+        $builder = factory(CentreUser::class);
 
-		// Lambeth SP user for testing
-		$lambethUser = factory(CentreUser::class)->create([
-			'name' => 'Lambeth SP user',
-			'email' => 'arc+lambethuser@neontribe.co.uk',
-			'password' => bcrypt('store_pass'),
-		]);
-		$lambethUser->centres()->attach(11, ['homeCentre' => true]);
+        if ($state !== '') {
+            $builder = $builder->state($state);
+        }
+
+        $user = $builder->create($attributes);
+        $user->centres()->attach($centreId, ['homeCentre' => $isHome]);
+
+        return $user;
     }
 }

--- a/database/seeders/CentreUsersSeeder.php
+++ b/database/seeders/CentreUsersSeeder.php
@@ -53,13 +53,13 @@ class CentreUsersSeeder extends Seeder
     private function seedNamedUsers(): void
     {
         $users = [
-            ['FMUser', 'ARC FM User', 'arc+fmuser@exmaple.com', 1],
-            ['FMUser', 'ARC fmuser2', 'arc+fmuser2@exmaple.com', 2],
-            ['', 'prescribing user', 'arc+spuser@exmaple.com', 'Prescribing Centre'],
-            ['', 'Scottish user', 'arc+scuser@exmaple.com', 8],
-            ['', 'Southwark user', 'arc+swuser@exmaple.com', 6],
-            ['', 'Tower Hamlet SP user', 'arc+thuser@exmaple.com', 10],
-            ['', 'Lambeth SP user', 'arc+lambethuser@exmaple.com', 11],
+            ['FMUser', 'ARC FM User', 'arc+fmuser@neontribe.co.uk', 1],
+            ['FMUser', 'ARC fmuser2', 'arc+fmuser2@neontribe.co.uk', 2],
+            ['', 'prescribing user', 'arc+spuser@neontribe.co.uk', 'Prescribing Centre'],
+            ['', 'Scottish user', 'arc+scuser@neontribe.co.uk', 8],
+            ['', 'Southwark user', 'arc+swuser@neontribe.co.uk', 6],
+            ['', 'Tower Hamlet SP user', 'arc+thuser@neontribe.co.uk', 10],
+            ['', 'Lambeth SP user', 'arc+lambethuser@neontribe.co.uk', 11],
         ];
 
         foreach ($users as [$state, $name, $email, $centre]) {

--- a/resources/views/service/centreusers/edit.blade.php
+++ b/resources/views/service/centreusers/edit.blade.php
@@ -80,10 +80,10 @@
             <button type="submit" id="toggleWorker">@empty($worker->deleted_at)Disable worker @else Enable worker @endif</button>
         </form>
         @if($worker->deleted_at)
-        <form role="form" id="deleteForm" class="styled-form" method="GET"
-            action="{{ route('admin.centreusers.delete', ['id' => $worker->id]) }}">
+        <form role="form" id="retireForm" class="styled-form" method="GET"
+            action="{{ route('admin.centreusers.retire', ['id' => $worker->id]) }}">
             {!! csrf_field() !!}
-          <button type="submit" id="deleteWorker" class="remove">Delete worker</button>
+          <button type="submit" id="retireWorker" class="remove">Retire worker</button>
         </form>
         @endif
         <script>
@@ -175,12 +175,12 @@
                     // show the boxes when we load
                     buildCheckboxes();
                 });
-                $('#deleteWorker').on('click', function (evt) {
+                $('#retireWorker').on('click', function (evt) {
                   evt.preventDefault();
-                  var deleteForm = document.getElementById('deleteForm');
-                  var areYouSure = confirm('Are you sure you want to PERMANENTLY delete this worker account?');
+                  var retireForm = document.getElementById('retireForm');
+                  var areYouSure = confirm('Are you sure you want to PERMANENTLY retire this worker account?');
                   if (areYouSure === true) {
-                    deleteForm.submit();
+                    retireForm.submit();
                   };
                 });
         </script>

--- a/routes/service.php
+++ b/routes/service.php
@@ -121,9 +121,9 @@ Route::group(['middleware' => 'auth:admin'], function () {
         'uses' => 'Admin\CentreUsersController@toggle',
     ])->where('id', '^[0-9]+$');
 
-    Route::get('workers/{id}/delete', [
-        'as' => 'admin.centreusers.delete',
-        'uses' => 'Admin\CentreUsersController@delete',
+    Route::get('workers/{id}/retire', [
+        'as' => 'admin.centreusers.retire',
+        'uses' => 'Admin\CentreUsersController@retire',
     ])->where('id', '^[0-9]+$');
 
     // Centre Management

--- a/tests/Feature/Service/EditWorkerPageTest.php
+++ b/tests/Feature/Service/EditWorkerPageTest.php
@@ -13,14 +13,13 @@ class EditWorkerPageTest extends StoreTestCase
 {
     use RefreshDatabase;
 
-    /** @var AdminUser $adminUser */
-    private $adminUser;
+    private AdminUser $adminUser;
 
-    /** @var Centre $centre */
-    private $centre;
+    private Centre $centre;
 
-    /** @var Collection $altCentres */
-    private $altCentres;
+    private Collection $altCentres;
+
+    private CentreUser $worker;
 
     public function setUp(): void
     {
@@ -28,20 +27,21 @@ class EditWorkerPageTest extends StoreTestCase
         $this->adminUser = factory(AdminUser::class)->create();
         $this->centre = factory(Centre::class)->create([]);
         $this->altCentres = factory(Centre::class, 2)->create([]);
-    }
 
-    /**
-     * @return void
-     */
-    public function testItShowsAWorkerEditPage(): void
-    {
-        // Make a CentreUser from the data with 1 homeCentre.
-        $cu = factory(CentreUser::class)->create([
-            'name' => 'testman',
+        $this->worker = factory(CentreUser::class)->create([
+            'name'  => 'testman',
             'email' => 'testman@test.co.uk',
         ]);
-        $cu->centres()->attach($this->altCentres->last()->id, ['homeCentre' => true]);
-        $workerEditRoute = route('admin.centreusers.edit', ['id' => $cu->id,]);
+        $this->worker->centres()->attach($this->centre->id, ['homeCentre' => true]);
+    }
+
+    // -----------------------------------------------------------------------
+    // Page structure — active worker
+    // -----------------------------------------------------------------------
+
+    public function testItShowsAWorkerEditPage(): void
+    {
+        $workerEditRoute = route('admin.centreusers.edit', ['id' => $this->worker->id]);
 
         $this->actingAs($this->adminUser, 'admin')
             ->get($workerEditRoute)
@@ -57,6 +57,143 @@ class EditWorkerPageTest extends StoreTestCase
             ->seeElement('label[for="downloader"]')
             ->seeInElement('label[for="downloader"]', 'Downloader Status')
             ->seeElement('select[name="downloader"]')
+        ;
+    }
+
+    public function testActiveWorkerShowsUpdateButton(): void
+    {
+        $this->actingAs($this->adminUser, 'admin')
+            ->get(route('admin.centreusers.edit', ['id' => $this->worker->id]))
+            ->assertResponseOk()
+            ->seeElement('#updateWorker')
+        ;
+    }
+
+    public function testActiveWorkerShowsDisableButtonNotEnableButton(): void
+    {
+        $this->actingAs($this->adminUser, 'admin')
+            ->get(route('admin.centreusers.edit', ['id' => $this->worker->id]))
+            ->assertResponseOk()
+            ->seeInElement('#toggleWorker', 'Disable worker')
+            ->dontSeeInElement('#toggleWorker', 'Enable worker')
+        ;
+    }
+
+    public function testActiveWorkerDoesNotShowRetireForm(): void
+    {
+        $this->actingAs($this->adminUser, 'admin')
+            ->get(route('admin.centreusers.edit', ['id' => $this->worker->id]))
+            ->assertResponseOk()
+            ->dontSeeElement('#retireForm')
+            ->dontSeeElement('#retireWorker')
+        ;
+    }
+
+    public function testActiveWorkerDoesNotShowDisabledMessage(): void
+    {
+        $this->actingAs($this->adminUser, 'admin')
+            ->get(route('admin.centreusers.edit', ['id' => $this->worker->id]))
+            ->assertResponseOk()
+            ->dontSee('This worker is')
+        ;
+    }
+
+    public function testWorkerHomeCentreIsPreselectedInDropdown(): void
+    {
+        $this->actingAs($this->adminUser, 'admin')
+            ->get(route('admin.centreusers.edit', ['id' => $this->worker->id]))
+            ->assertResponseOk()
+            ->seeElement('option[value="' . $this->centre->id . '"][selected]')
+        ;
+    }
+
+    public function testWorkerAlternativeCentresAreRenderedAsOptions(): void
+    {
+        $this->worker->centres()->attach([
+            $this->altCentres[0]->id => ['homeCentre' => false],
+            $this->altCentres[1]->id => ['homeCentre' => false],
+        ]);
+
+        $this->actingAs($this->adminUser, 'admin')
+            ->get(route('admin.centreusers.edit', ['id' => $this->worker->id]))
+            ->assertResponseOk()
+            ->seeElement('option[value="' . $this->altCentres[0]->id . '"]')
+            ->seeElement('option[value="' . $this->altCentres[1]->id . '"]')
+        ;
+    }
+
+    // -----------------------------------------------------------------------
+    // Page structure — disabled (soft-deleted) worker
+    // -----------------------------------------------------------------------
+
+    public function testDisabledWorkerShowsDisabledMessage(): void
+    {
+        $this->worker->delete();
+
+        $this->actingAs($this->adminUser, 'admin')
+            ->get(route('admin.centreusers.edit', ['id' => $this->worker->id]))
+            ->assertResponseOk()
+            ->seeInElement('h2', 'This worker is')
+            ->seeInElement('h2 i', 'disabled')
+        ;
+    }
+
+    public function testDisabledWorkerDoesNotShowUpdateButton(): void
+    {
+        $this->worker->delete();
+
+        $this->actingAs($this->adminUser, 'admin')
+            ->get(route('admin.centreusers.edit', ['id' => $this->worker->id]))
+            ->assertResponseOk()
+            ->dontSeeElement('#updateWorker')
+        ;
+    }
+
+    public function testDisabledWorkerShowsEnableButtonNotDisableButton(): void
+    {
+        $this->worker->delete();
+
+        $this->actingAs($this->adminUser, 'admin')
+            ->get(route('admin.centreusers.edit', ['id' => $this->worker->id]))
+            ->assertResponseOk()
+            ->seeInElement('#toggleWorker', 'Enable worker')
+            ->dontSeeInElement('#toggleWorker', 'Disable worker')
+        ;
+    }
+
+    public function testDisabledWorkerShowsRetireForm(): void
+    {
+        $this->worker->delete();
+
+        $this->actingAs($this->adminUser, 'admin')
+            ->get(route('admin.centreusers.edit', ['id' => $this->worker->id]))
+            ->assertResponseOk()
+            ->seeElement('#retireForm')
+            ->seeElement('#retireWorker')
+        ;
+    }
+
+    public function testDisabledWorkerRetireFormPostsToCorrectRoute(): void
+    {
+        $this->worker->delete();
+
+        $this->actingAs($this->adminUser, 'admin')
+            ->get(route('admin.centreusers.edit', ['id' => $this->worker->id]))
+            ->assertResponseOk()
+            ->seeElement(
+                '#retireForm[action="' . route('admin.centreusers.retire', ['id' => $this->worker->id]) . '"]'
+            )
+        ;
+    }
+
+    // -----------------------------------------------------------------------
+    // Access control
+    // -----------------------------------------------------------------------
+
+    public function testUnauthenticatedUserCannotAccessEditPage(): void
+    {
+        $this->get(route('admin.centreusers.edit', ['id' => $this->worker->id]))
+            ->assertResponseStatus(302)
         ;
     }
 }

--- a/tests/Stubs/TestRetirableModel.php
+++ b/tests/Stubs/TestRetirableModel.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Stubs;
+
+use App\Traits\Retirable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
+
+/**
+ * Minimal stub model for testing the Retirable trait in isolation.
+ *
+ * Mirrors the same nullability constraints as a typical user table:
+ * name, email, and password are non-nullable; remember_token is nullable.
+ */
+class TestRetirableModel extends Model
+{
+    use SoftDeletes;
+    use Retirable;
+
+    protected $table = 'retirable_stubs';
+
+    protected $fillable = ['name', 'email', 'password', 'remember_token'];
+
+    protected function retirableFields(): array
+    {
+        return [
+            'name'           => 'retired',
+            'email'          => 'retired_' . Str::uuid() . '@retired.invalid',
+            'password'       => Hash::make(Str::uuid()),
+            'remember_token' => null,
+        ];
+    }
+}

--- a/tests/Unit/Controllers/Service/Admin/CentreUserControllerTest.php
+++ b/tests/Unit/Controllers/Service/Admin/CentreUserControllerTest.php
@@ -46,8 +46,7 @@ class CentreUserControllerTest extends StoreTestCase
             ->assertResponseOk()
             ->seePageIs(route('admin.centreusers.index'))
             ->see($this->data["name"])
-            ->see($this->data["email"])
-        ;
+            ->see($this->data["email"]);
         // find the user
         $cu = CentreUser::where('email', $this->data['email'])->first();
         $this->assertNotNull($cu);
@@ -70,7 +69,7 @@ class CentreUserControllerTest extends StoreTestCase
         $this->seeInDatabase('centre_users', [
             'name' => $cu->name,
             'email' => $cu->email,
-            'downloader' => $cu->downloader
+            'downloader' => $cu->downloader,
         ]);
         // Check that worked.
         $this->assertCount(1, $cu->centres);
@@ -94,14 +93,12 @@ class CentreUserControllerTest extends StoreTestCase
             ->seeInDatabase('centre_users', [
                 'name' => $this->data['name'],
                 'email' => $this->data['email'],
-                'downloader' => $this->data['downloader']
+                'downloader' => $this->data['downloader'],
             ])
             ->dontSeeInDatabase('centre_users', [
                 'name' => $cu->name,
                 'email' => $cu->email,
-            ])
-        ;
-        ;
+            ]);
         // find the user
         $cu = CentreUser::where('email', $this->data['email'])->first();
         $this->assertNotNull($cu);
@@ -131,18 +128,16 @@ class CentreUserControllerTest extends StoreTestCase
             )
             ->followRedirects()
             ->assertResponseOk()
-            // returns to edit page
             ->seePageIs(route('admin.centreusers.edit', ['id' => $cu->id]))
-            // retains old information
+            // Centre pivot relations are preserved on disable.
             ->seeInDatabase('centre_centre_user', [
                 'centre_user_id' => $cu->id,
                 'centre_id' => $this->altCentres->last()->id,
-            ])
-            ->see('This worker is <i>disabled</i>')
-            ->seeInElement('#toggleWorker', ' Enable worker')
-            // There is a delete button
-            ->seeElement('#deleteWorker')
-        ;
+            ]);
+
+        // Record is soft-deleted but still present.
+        $this->assertNull(CentreUser::find($cu->id));
+        $this->assertNotNull(CentreUser::withTrashed()->find($cu->id)->deleted_at);
     }
 
     public function testItCanEnableACentreUser(): void
@@ -150,7 +145,7 @@ class CentreUserControllerTest extends StoreTestCase
         $cu = factory(CentreUser::class)->create([
             'name' => "testman",
             'email' => "testman@test.co.uk",
-            'deleted_at' => date("Y-m-d H:i:s")
+            'deleted_at' => date("Y-m-d H:i:s"),
         ]);
         $cu->centres()->attach($this->altCentres->last()->id, ['homeCentre' => true]);
 
@@ -166,16 +161,16 @@ class CentreUserControllerTest extends StoreTestCase
             )
             ->followRedirects()
             ->assertResponseOk()
-            // returns to edit page
             ->seePageIs(route('admin.centreusers.edit', ['id' => $cu->id]))
-            // retains old information
+            // Centre pivot relations are preserved on enable.
             ->seeInDatabase('centre_centre_user', [
                 'centre_user_id' => $cu->id,
                 'centre_id' => $this->altCentres->last()->id,
-            ])
-            ->dontSee('This worker is <i>disabled</i>')
-            ->seeInElement('#toggleWorker', 'Disable worker')
-        ;
+            ]);
+
+        // Record is restored and findable without withTrashed().
+        $this->assertNotNull(CentreUser::find($cu->id));
+        $this->assertNull(CentreUser::find($cu->id)->deleted_at);
     }
 
     public function testICanSeeDisabledCentreUsers(): void
@@ -183,20 +178,19 @@ class CentreUserControllerTest extends StoreTestCase
         $cu = factory(CentreUser::class)->create([
             'name' => "testman",
             'email' => "testman@test.co.uk",
-            'deleted_at' => date("Y-m-d H:i:s")
+            'deleted_at' => date("Y-m-d H:i:s"),
         ]);
 
         $this->seeInDatabase('centre_users', [
             'name' => $cu->name,
             'email' => $cu->email,
-            'deleted_at' => date("Y-m-d H:i:s")
+            'deleted_at' => date("Y-m-d H:i:s"),
         ]);
 
         $this->actingAs($this->adminUser, 'admin')
             ->visit(route('admin.centreusers.index'))
             ->assertResponseOk()
-            ->see($cu->email)
-        ;
+            ->see($cu->email);
     }
 
     public function testICannotSeeDeletedCentreUsers(): void
@@ -204,13 +198,13 @@ class CentreUserControllerTest extends StoreTestCase
         $cu = factory(CentreUser::class)->create([
             'name' => "testman",
             'email' => "testman@test.co.uk",
-            'deleted_at' => date("Y-m-d H:i:s")
+            'deleted_at' => date("Y-m-d H:i:s"),
         ]);
 
         $this->seeInDatabase('centre_users', [
             'name' => $cu->name,
             'email' => $cu->email,
-            'deleted_at' => date("Y-m-d H:i:s")
+            'deleted_at' => date("Y-m-d H:i:s"),
         ]);
 
         // remove it!
@@ -219,7 +213,76 @@ class CentreUserControllerTest extends StoreTestCase
         $this->actingAs($this->adminUser, 'admin')
             ->visit(route('admin.centreusers.index'))
             ->assertResponseOk()
-            ->dontSee($cu->email)
-        ;
+            ->dontSee($cu->email);
+    }
+
+    // -----------------------------------------------------------------------
+    // Retire action
+    // -----------------------------------------------------------------------
+
+    public function testRetiringADisabledWorkerWipesTheirPiiAndRedirectsToIndex(): void
+    {
+        $cu = factory(CentreUser::class)->create();
+        $cu->centres()->attach($this->centre->id, ['homeCentre' => true]);
+        $cu->delete();
+
+        $this->actingAs($this->adminUser, 'admin')
+            ->get(route('admin.centreusers.retire', ['id' => $cu->id]))
+            ->assertRedirectedToRoute('admin.centreusers.index')
+            ->assertSessionHas('message');
+
+        $retired = CentreUser::withTrashed()->find($cu->id);
+        $this->assertNotNull($retired->retired_at);
+        $this->assertSame('[User Retired]', $retired->name);
+        $this->assertStringStartsWith('retired_', $retired->email);
+        $this->assertStringEndsWith('@retired.invalid', $retired->email);
+    }
+
+    public function testRetiringADisabledWorkerRetainsTheirCentreRelations(): void
+    {
+        $cu = factory(CentreUser::class)->create();
+        $cu->centres()->attach($this->centre->id, ['homeCentre' => true]);
+        $cu->delete();
+
+        $this->actingAs($this->adminUser, 'admin')
+            ->get(route('admin.centreusers.retire', ['id' => $cu->id]));
+
+        $this->seeInDatabase('centre_centre_user', [
+            'centre_user_id' => $cu->id,
+            'centre_id' => $this->centre->id,
+        ]);
+    }
+
+    public function testRetiringAnActiveNonTrashedWorkerReturns404(): void
+    {
+        $cu = factory(CentreUser::class)->create();
+
+        $this->actingAs($this->adminUser, 'admin')
+            ->get(route('admin.centreusers.retire', ['id' => $cu->id]))
+            ->assertResponseStatus(404);
+    }
+
+    public function testRetiredWorkerCannotBeToggled(): void
+    {
+        $cu = factory(CentreUser::class)->create();
+        $cu->centres()->attach($this->centre->id, ['homeCentre' => true]);
+        $cu->delete();
+        $cu->retire();
+
+        $this->actingAs($this->adminUser, 'admin')
+            ->get(route('admin.centreusers.toggle', $cu->id));
+
+        // retired_at must still be set — the restoring event blocked the restore.
+        $this->assertNotNull(CentreUser::withTrashed()->find($cu->id)->retired_at);
+    }
+
+    public function testRetiredWorkerDoesNotAppearOnIndex(): void
+    {
+        $cu = factory(CentreUser::class)->state('retired')->create();
+
+        $this->actingAs($this->adminUser, 'admin')
+            ->visit(route('admin.centreusers.index'))
+            ->assertResponseOk()
+            ->dontSee($cu->email);
     }
 }

--- a/tests/Unit/Controllers/Service/Admin/CentreUserControllerTest.php
+++ b/tests/Unit/Controllers/Service/Admin/CentreUserControllerTest.php
@@ -137,7 +137,7 @@ class CentreUserControllerTest extends StoreTestCase
 
         // Record is soft-deleted but still present.
         $this->assertNull(CentreUser::find($cu->id));
-        $this->assertNotNull(CentreUser::withTrashed()->find($cu->id)->deleted_at);
+        $this->assertNotNull(CentreUser::withTrashed()->find($cu->id));
     }
 
     public function testItCanEnableACentreUser(): void

--- a/tests/Unit/Models/CentreUserModelTest.php
+++ b/tests/Unit/Models/CentreUserModelTest.php
@@ -5,8 +5,10 @@ namespace Tests\Unit\Models;
 use App\Centre;
 use App\CentreUser;
 use App\Note;
-use Tests\TestCase;
+use DomainException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
 
 class CentreUserModelTest extends TestCase
 {
@@ -14,6 +16,7 @@ class CentreUserModelTest extends TestCase
 
     protected $centreUser;
     protected $notes;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -88,5 +91,96 @@ class CentreUserModelTest extends TestCase
 
         // But We have no homeCentre
         $this->assertEmpty($cu->homeCentre);
+    }
+
+    // -----------------------------------------------------------------------
+    // Retirable — CentreUser-specific tests
+    //
+    // These tests cover the concrete PII replacement values declared in
+    // CentreUser::retirableFields() and the survival of CentreUser's own
+    // relations after retirement. Generic trait behaviour (idempotency,
+    // soft-delete, scopes, boot guard) is covered in RetirableTest.
+    // -----------------------------------------------------------------------
+
+    public function testCentreUserIsNotRetiredByDefault(): void
+    {
+        $this->assertFalse($this->centreUser->isRetired());
+        $this->assertNull($this->centreUser->retired_at);
+    }
+
+    public function testRetiredCentreUserHasNameCleared(): void
+    {
+        $this->centreUser->retire();
+
+        $fresh = CentreUser::withTrashed()->find($this->centreUser->id);
+        $this->assertSame('[User Retired]', $fresh->name);
+    }
+
+    public function testRetiredCentreUserHasEmailReplacedWithSafeRetiredPlaceholder(): void
+    {
+        $originalEmail = $this->centreUser->email; // capture before retire() mutates the instance
+
+        $this->centreUser->retire();
+
+        $email = CentreUser::withTrashed()->find($this->centreUser->id)->email;
+
+        // Confirm format matches CentreUser::retirableFields() convention.
+        $this->assertStringStartsWith('retired_', $email);
+        $this->assertStringEndsWith('@retired.invalid', $email);
+
+        // Confirm the original email is gone.
+        $this->assertNotSame($originalEmail, $email);
+    }
+
+    public function testRetiredCentreUserHasPasswordReplacedWithANewHash(): void
+    {
+        $originalPassword = $this->centreUser->password; // capture before retire() mutates the instance
+
+        $this->centreUser->retire();
+
+        $replacedPassword = CentreUser::withTrashed()->find($this->centreUser->id)->password;
+
+        $this->assertTrue(Hash::isHashed($replacedPassword));
+        $this->assertNotSame($originalPassword, $replacedPassword);
+    }
+
+    public function testRetiredCentreUserHasRememberTokenCleared(): void
+    {
+        $this->centreUser->retire();
+
+        $fresh = CentreUser::withTrashed()->find($this->centreUser->id);
+        $this->assertNull($fresh->remember_token);
+    }
+
+    public function testRetiredCentreUserRetainsNoteRelations(): void
+    {
+        // Notes exist before retirement.
+        $this->assertCount(2, $this->centreUser->notes);
+
+        $this->centreUser->retire();
+
+        // Notes are still associated via FK after retirement.
+        $fresh = CentreUser::withTrashed()->find($this->centreUser->id);
+        $this->assertCount(2, $fresh->notes);
+    }
+
+    public function testRetiredCentreUserRetainsCentreRelations(): void
+    {
+        $centre = factory(Centre::class)->create();
+        $this->centreUser->centres()->attach($centre->id, ['homeCentre' => true]);
+
+        $this->centreUser->retire();
+
+        $fresh = CentreUser::withTrashed()->find($this->centreUser->id);
+        $this->assertEquals(1, $fresh->centres()->count());
+    }
+
+    public function testRetiredCentreUserCannotBeRestored(): void
+    {
+        $cu = factory(CentreUser::class)->state('retired')->create()->fresh();
+
+        $this->expectException(DomainException::class);
+
+        CentreUser::withTrashed()->find($cu->id)->restore();
     }
 }

--- a/tests/Unit/Models/CentreUserModelTest.php
+++ b/tests/Unit/Models/CentreUserModelTest.php
@@ -70,9 +70,9 @@ class CentreUserModelTest extends TestCase
         $cu->centres()->attach($centre->id, ['homeCentre' => true]);
 
         // There is one
-        $this->assertEquals(1, $cu->centres()->count());
+        $this->assertSame(1, $cu->centres()->count());
         // It is the homeCentre
-        $this->assertEquals($centre->id, $cu->homeCentre->id);
+        $this->assertSame($centre->id, $cu->homeCentre->id);
     }
 
 
@@ -87,7 +87,7 @@ class CentreUserModelTest extends TestCase
         $cu->centres()->attach($centres->pluck('id')->all());
 
         // There is 4
-        $this->assertEquals(4, $cu->centres()->count());
+        $this->assertSame(4, $cu->centres()->count());
 
         // But We have no homeCentre
         $this->assertEmpty($cu->homeCentre);
@@ -172,7 +172,7 @@ class CentreUserModelTest extends TestCase
         $this->centreUser->retire();
 
         $fresh = CentreUser::withTrashed()->find($this->centreUser->id);
-        $this->assertEquals(1, $fresh->centres()->count());
+        $this->assertSame(1, $fresh->centres()->count());
     }
 
     public function testRetiredCentreUserCannotBeRestored(): void

--- a/tests/Unit/Models/CentreUserModelTest.php
+++ b/tests/Unit/Models/CentreUserModelTest.php
@@ -155,14 +155,15 @@ class CentreUserModelTest extends TestCase
     public function testRetiredCentreUserRetainsNoteRelations(): void
     {
         // Notes exist before retirement.
-        $this->assertCount(2, $this->centreUser->notes);
+        $notesCount = count($this->centreUser->notes);
+        $this->assertCount($notesCount, $this->centreUser->notes);
 
         $this->centreUser->delete();
         $this->centreUser->retire();
 
         // Notes are still associated via FK after retirement.
         $fresh = CentreUser::withTrashed()->find($this->centreUser->id);
-        $this->assertCount(2, $fresh->notes);
+        $this->assertCount($notesCount, $fresh->notes);
     }
 
     public function testRetiredCentreUserRetainsCentreRelations(): void

--- a/tests/Unit/Models/CentreUserModelTest.php
+++ b/tests/Unit/Models/CentreUserModelTest.php
@@ -70,9 +70,9 @@ class CentreUserModelTest extends TestCase
         $cu->centres()->attach($centre->id, ['homeCentre' => true]);
 
         // There is one
-        $this->assertEquals(1, $cu->centres()->count());
+        $this->assertSame(1, $cu->centres()->count());
         // It is the homeCentre
-        $this->assertEquals($centre->id, $cu->homeCentre->id);
+        $this->assertSame($centre->id, $cu->homeCentre->id);
     }
 
 
@@ -87,7 +87,7 @@ class CentreUserModelTest extends TestCase
         $cu->centres()->attach($centres->pluck('id')->all());
 
         // There is 4
-        $this->assertEquals(4, $cu->centres()->count());
+        $this->assertSame(4, $cu->centres()->count());
 
         // But We have no homeCentre
         $this->assertEmpty($cu->homeCentre);
@@ -110,16 +110,16 @@ class CentreUserModelTest extends TestCase
 
     public function testRetiredCentreUserHasNameCleared(): void
     {
-        $this->centreUser->retire();
+        $cu = factory(CentreUser::class)->state('retired')->create()->fresh();
 
-        $fresh = CentreUser::withTrashed()->find($this->centreUser->id);
-        $this->assertSame('[User Retired]', $fresh->name);
+        $this->assertSame('[User Retired]', $cu->name);
     }
 
     public function testRetiredCentreUserHasEmailReplacedWithSafeRetiredPlaceholder(): void
     {
         $originalEmail = $this->centreUser->email; // capture before retire() mutates the instance
 
+        $this->centreUser->delete();
         $this->centreUser->retire();
 
         $email = CentreUser::withTrashed()->find($this->centreUser->id)->email;
@@ -136,6 +136,7 @@ class CentreUserModelTest extends TestCase
     {
         $originalPassword = $this->centreUser->password; // capture before retire() mutates the instance
 
+        $this->centreUser->delete();
         $this->centreUser->retire();
 
         $replacedPassword = CentreUser::withTrashed()->find($this->centreUser->id)->password;
@@ -146,10 +147,9 @@ class CentreUserModelTest extends TestCase
 
     public function testRetiredCentreUserHasRememberTokenCleared(): void
     {
-        $this->centreUser->retire();
+        $cu = factory(CentreUser::class)->state('retired')->create()->fresh();
 
-        $fresh = CentreUser::withTrashed()->find($this->centreUser->id);
-        $this->assertNull($fresh->remember_token);
+        $this->assertNull($cu->remember_token);
     }
 
     public function testRetiredCentreUserRetainsNoteRelations(): void
@@ -157,6 +157,7 @@ class CentreUserModelTest extends TestCase
         // Notes exist before retirement.
         $this->assertCount(2, $this->centreUser->notes);
 
+        $this->centreUser->delete();
         $this->centreUser->retire();
 
         // Notes are still associated via FK after retirement.
@@ -169,10 +170,11 @@ class CentreUserModelTest extends TestCase
         $centre = factory(Centre::class)->create();
         $this->centreUser->centres()->attach($centre->id, ['homeCentre' => true]);
 
+        $this->centreUser->delete();
         $this->centreUser->retire();
 
         $fresh = CentreUser::withTrashed()->find($this->centreUser->id);
-        $this->assertEquals(1, $fresh->centres()->count());
+        $this->assertSame(1, $fresh->centres()->count());
     }
 
     public function testRetiredCentreUserCannotBeRestored(): void

--- a/tests/Unit/Traits/RetirableTest.php
+++ b/tests/Unit/Traits/RetirableTest.php
@@ -101,9 +101,20 @@ class RetirableTest extends TestCase
     // -----------------------------------------------------------------------
 
 
+    public function testRetireThrowsDomainExceptionIfModelIsNotSoftDeleted(): void
+    {
+        $stub = $this->makeStub();
+
+        $this->expectException(DomainException::class);
+        $this->expectExceptionMessage('must be disabled before it can be retired');
+
+        $stub->retire();
+    }
+
     public function testRetireSetsRetiredAtToCurrentTime(): void
     {
         $stub = $this->makeStub();
+        $stub->delete();
 
         $stub->retire();
 
@@ -111,19 +122,10 @@ class RetirableTest extends TestCase
     }
 
 
-    public function testRetireSoftDeletesTheModel(): void
-    {
-        $stub = $this->makeStub();
-
-        $stub->retire();
-
-        $this->assertSoftDeleted('retirable_stubs', ['id' => $stub->id]);
-    }
-
-
     public function testRetireReplacesEachFieldDeclaredInRetirableFields(): void
     {
         $stub = $this->makeStub();
+        $stub->delete();
         $originalEmail = $stub->email;
         $originalPassword = $stub->password;
 
@@ -140,6 +142,7 @@ class RetirableTest extends TestCase
     public function testRetireStoresAValidEmailPlaceholder(): void
     {
         $stub = $this->makeStub();
+        $stub->delete();
 
         $stub->retire();
 
@@ -153,6 +156,7 @@ class RetirableTest extends TestCase
     public function testRetireStoresAHashedPasswordNotPlainText(): void
     {
         $stub = $this->makeStub();
+        $stub->delete();
 
         $stub->retire();
 
@@ -165,6 +169,7 @@ class RetirableTest extends TestCase
     public function testRetireIsIdempotentAndDoesNotChangeFieldsOnSecondCall(): void
     {
         $stub = $this->makeStub();
+        $stub->delete();
         $stub->retire();
 
         $afterFirst = TestRetirableModel::withTrashed()->find($stub->id);
@@ -185,7 +190,9 @@ class RetirableTest extends TestCase
         $first = $this->makeStub(['email' => 'first@example.com']);
         $second = $this->makeStub(['email' => 'second@example.com']);
 
+        $first->delete();
         $first->retire();
+        $second->delete();
         $second->retire();
 
         $emailFirst = TestRetirableModel::withTrashed()->find($first->id)->email;
@@ -210,6 +217,7 @@ class RetirableTest extends TestCase
     public function testIsRetiredReturnsTrueAfterRetirement(): void
     {
         $stub = $this->makeStub();
+        $stub->delete();
 
         $stub->retire();
 
@@ -224,6 +232,7 @@ class RetirableTest extends TestCase
     public function testRestoringARetiredModelThrowsADomainException(): void
     {
         $stub = $this->makeStub();
+        $stub->delete();
         $stub->retire();
 
         $this->expectException(DomainException::class);
@@ -255,6 +264,7 @@ class RetirableTest extends TestCase
         $retired = $this->makeStub(['email' => 'retired@example.com']);
 
         $deleted->delete();
+        $retired->delete();
         $retired->retire();
 
         $results = TestRetirableModel::retired()->get();
@@ -271,6 +281,7 @@ class RetirableTest extends TestCase
         $retired = $this->makeStub(['email' => 'retired@example.com']);
 
         $deleted->delete();
+        $retired->delete();
         $retired->retire();
 
         $results = TestRetirableModel::active()->get();

--- a/tests/Unit/Traits/RetirableTest.php
+++ b/tests/Unit/Traits/RetirableTest.php
@@ -113,12 +113,17 @@ class RetirableTest extends TestCase
 
     public function testRetireSetsRetiredAtToCurrentTime(): void
     {
+        // Freeze Time!
+        $now = Carbon::now();
+        Carbon::setTestNow($now);
+
         $stub = $this->makeStub();
         $stub->delete();
-
         $stub->retire();
+        $this->assertSame($now->toDateTimeString(), $stub->fresh()->retired_at->toDateTimeString());
 
-        $this->assertNotNull($stub->fresh()->retired_at);
+        // reset time!
+        Carbon::setTestNow();
     }
 
 

--- a/tests/Unit/Traits/RetirableTest.php
+++ b/tests/Unit/Traits/RetirableTest.php
@@ -1,0 +1,281 @@
+<?php
+
+namespace Tests\Unit\Traits;
+
+use App\Traits\Retirable;
+use DomainException;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Schema;
+use LogicException;
+use Tests\Stubs\TestRetirableModel;
+use Tests\TestCase;
+
+/**
+ * Intentionally omits SoftDeletes to verify the boot-time guard.
+ * Kept here rather than in Stubs as it has no use outside this test.
+ */
+class RetirableWithoutSoftDeletesStub extends Model
+{
+    use Retirable;
+
+    protected $table = 'retirable_stubs';
+}
+
+class RetirableTest extends TestCase
+{
+    // -----------------------------------------------------------------------
+    // Schema setup
+    // -----------------------------------------------------------------------
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('retirable_stubs', static function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->string('password');
+            $table->string('remember_token')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+            $table->timestamp('retired_at')->nullable();
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        Schema::dropIfExists('retirable_stubs');
+
+        // Clear Eloquent's static boot cache so each test begins with a clean
+        // boot cycle — essential for the boot guard test to be repeatable.
+        Model::clearBootedModels();
+
+        parent::tearDown();
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private function makeStub(array $attributes = []): TestRetirableModel
+    {
+        return TestRetirableModel::create(array_merge([
+            'name' => 'Original Name',
+            'email' => 'original@example.com',
+            'password' => Hash::make('secret'),
+        ], $attributes));
+    }
+
+    // -----------------------------------------------------------------------
+    // Boot guard
+    // -----------------------------------------------------------------------
+
+
+    public function testBootRetirableThrowsLogicExceptionIfSoftDeletesIsNotUsed(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('must use SoftDeletes');
+
+        new RetirableWithoutSoftDeletesStub();
+    }
+
+    // -----------------------------------------------------------------------
+    // Cast registration
+    // -----------------------------------------------------------------------
+
+
+    public function testRetiredAtIsAutomaticallyCastToDatetime(): void
+    {
+        $stub = $this->makeStub();
+        $stub->retired_at = now();
+
+        $this->assertInstanceOf(Carbon::class, $stub->retired_at);
+    }
+
+    // -----------------------------------------------------------------------
+    // retire()
+    // -----------------------------------------------------------------------
+
+
+    public function testRetireSetsRetiredAtToCurrentTime(): void
+    {
+        $stub = $this->makeStub();
+
+        $stub->retire();
+
+        $this->assertNotNull($stub->fresh()->retired_at);
+    }
+
+
+    public function testRetireSoftDeletesTheModel(): void
+    {
+        $stub = $this->makeStub();
+
+        $stub->retire();
+
+        $this->assertSoftDeleted('retirable_stubs', ['id' => $stub->id]);
+    }
+
+
+    public function testRetireReplacesEachFieldDeclaredInRetirableFields(): void
+    {
+        $stub = $this->makeStub();
+        $originalEmail = $stub->email;
+        $originalPassword = $stub->password;
+
+        $stub->retire();
+
+        $fresh = TestRetirableModel::withTrashed()->find($stub->id);
+
+        $this->assertNotSame($originalEmail, $fresh->email);
+        $this->assertNotSame($originalPassword, $fresh->password);
+        $this->assertNull($fresh->remember_token);
+    }
+
+
+    public function testRetireStoresAValidEmailPlaceholder(): void
+    {
+        $stub = $this->makeStub();
+
+        $stub->retire();
+
+        $email = TestRetirableModel::withTrashed()->find($stub->id)->email;
+
+        $this->assertStringStartsWith('retired_', $email);
+        $this->assertStringEndsWith('@retired.invalid', $email);
+    }
+
+
+    public function testRetireStoresAHashedPasswordNotPlainText(): void
+    {
+        $stub = $this->makeStub();
+
+        $stub->retire();
+
+        $password = TestRetirableModel::withTrashed()->find($stub->id)->password;
+
+        $this->assertTrue(Hash::isHashed($password));
+    }
+
+
+    public function testRetireIsIdempotentAndDoesNotChangeFieldsOnSecondCall(): void
+    {
+        $stub = $this->makeStub();
+        $stub->retire();
+
+        $afterFirst = TestRetirableModel::withTrashed()->find($stub->id);
+        $emailAfterFirst = $afterFirst->email;
+        $retiredAtAfterFirst = $afterFirst->retired_at->toDateTimeString();
+
+        $stub->retire();
+
+        $afterSecond = TestRetirableModel::withTrashed()->find($stub->id);
+
+        $this->assertSame($emailAfterFirst, $afterSecond->email);
+        $this->assertSame($retiredAtAfterFirst, $afterSecond->retired_at->toDateTimeString());
+    }
+
+
+    public function testTwoSeparatelyRetiredModelsReceiveUniqueEmailPlaceholders(): void
+    {
+        $first = $this->makeStub(['email' => 'first@example.com']);
+        $second = $this->makeStub(['email' => 'second@example.com']);
+
+        $first->retire();
+        $second->retire();
+
+        $emailFirst = TestRetirableModel::withTrashed()->find($first->id)->email;
+        $emailSecond = TestRetirableModel::withTrashed()->find($second->id)->email;
+
+        $this->assertNotSame($emailFirst, $emailSecond);
+    }
+
+    // -----------------------------------------------------------------------
+    // isRetired()
+    // -----------------------------------------------------------------------
+
+
+    public function testIsRetiredReturnsFalseForAnActiveModel(): void
+    {
+        $stub = $this->makeStub();
+
+        $this->assertFalse($stub->isRetired());
+    }
+
+
+    public function testIsRetiredReturnsTrueAfterRetirement(): void
+    {
+        $stub = $this->makeStub();
+
+        $stub->retire();
+
+        $this->assertTrue($stub->isRetired());
+    }
+
+    // -----------------------------------------------------------------------
+    // Restore guard (restoring event)
+    // -----------------------------------------------------------------------
+
+
+    public function testRestoringARetiredModelThrowsADomainException(): void
+    {
+        $stub = $this->makeStub();
+        $stub->retire();
+
+        $this->expectException(DomainException::class);
+        $this->expectExceptionMessage('cannot be restored');
+
+        TestRetirableModel::withTrashed()->find($stub->id)->restore();
+    }
+
+
+    public function testRestoringAMerelySoftDeletedModelSucceeds(): void
+    {
+        $stub = $this->makeStub();
+        $stub->delete();
+
+        TestRetirableModel::withTrashed()->find($stub->id)->restore();
+
+        $this->assertNotSoftDeleted('retirable_stubs', ['id' => $stub->id]);
+    }
+
+    // -----------------------------------------------------------------------
+    // Scopes
+    // -----------------------------------------------------------------------
+
+
+    public function testScopeRetiredReturnsOnlyRetiredModels(): void
+    {
+        $active = $this->makeStub(['email' => 'active@example.com']);
+        $deleted = $this->makeStub(['email' => 'deleted@example.com']);
+        $retired = $this->makeStub(['email' => 'retired@example.com']);
+
+        $deleted->delete();
+        $retired->retire();
+
+        $results = TestRetirableModel::retired()->get();
+
+        $this->assertCount(1, $results);
+        $this->assertTrue($results->first()->is($retired));
+    }
+
+
+    public function testScopeActiveExcludesRetiredAndSoftDeletedModels(): void
+    {
+        $active = $this->makeStub(['email' => 'active@example.com']);
+        $deleted = $this->makeStub(['email' => 'deleted@example.com']);
+        $retired = $this->makeStub(['email' => 'retired@example.com']);
+
+        $deleted->delete();
+        $retired->retire();
+
+        $results = TestRetirableModel::active()->get();
+
+        $this->assertCount(1, $results);
+        $this->assertTrue($results->first()->is($active));
+    }
+}


### PR DESCRIPTION
https://trello.com/c/ytZJt1yn/2189-bug-permenently-deleting-a-centre-user-ee-vv

Further adventures in the claude assistance experiment.

- Created a migration to add retired_at as a field on centre users
- created a trait to :
  - augment soft deletes by intercepting and blocking restores for retired models
  - automating some of the boilerplate for retiring models
- update centre user so that it can be retired and picked some good   
- added tests for the trait and the new centre user behaviour
- updated factories and seeds for the new behaviour

next: updating the UX in admin to allow retiring