### PR TITLE
1.20/2189-bug-permenently-deleting-a-centre-user-ee-vv_part2

### DIFF
--- a/app/Http/Controllers/Service/Admin/CentreUsersController.php
+++ b/app/Http/Controllers/Service/Admin/CentreUsersController.php
@@ -23,16 +23,13 @@ use League\Csv\CannotInsertRecord;
 use Log;
 use Ramsey\Uuid\Uuid;
 use Throwable;
-use function PHPUnit\Framework\isNan;
 
 class CentreUsersController extends Controller
 {
     /**
      * Display a listing of Workers.
-     * @param AdminIndexCentreUsersRequest $request
-     * @return Application|Factory|View
      */
-    public function index(AdminIndexCentreUsersRequest $request): View|Factory|Application
+    public function index(AdminIndexCentreUsersRequest $request): Factory|View
     {
         // fetch query params from request
         $field = $request->input('orderBy');
@@ -47,7 +44,7 @@ class CentreUsersController extends Controller
                 return $homeCentre?->sponsor?->name . '#' . $homeCentre?->name . '#' . $item->name;
             },
         };
-        $workers = CentreUser::withTrashed()->get()->sortBy($sorter, SORT_REGULAR, ($direction === 'desc'));
+        $workers = CentreUser::withTrashed()->active()->get()->sortBy($sorter, SORT_REGULAR, ($direction === 'desc'));
 
         return view('service.centreusers.index', compact('workers'));
     }
@@ -101,12 +98,9 @@ class CentreUsersController extends Controller
 
     /**
      * Update a CentreUser from a form
-     * @param AdminUpdateCentreUserRequest $request
-     * @param $id
-     * @return RedirectResponse
      * @throws Throwable
      */
-    public function update(AdminUpdateCentreUserRequest $request, $id)
+    public function update(AdminUpdateCentreUserRequest $request, $id): RedirectResponse
     {
         try {
             $centreUser = DB::transaction(function () use ($request, $id) {
@@ -140,11 +134,8 @@ class CentreUsersController extends Controller
 
     /**
      * Code deduplication;
-     * @param Request $request
-     * @param CentreUser $cu
-     * @return array
      */
-    private function syncCentres(Request $request, CentreUser $cu): array
+    private function syncCentres(Request $request, CentreUser $cu): void
     {
         // Set Home Centre
         $homeCentre_id = $request->input('worker_centre');
@@ -162,13 +153,11 @@ class CentreUsersController extends Controller
             }
         }
         // Sync them setting pivots.
-        return $cu->centres()->sync($centre_ids);
+        $cu->centres()->sync($centre_ids);
     }
 
     /**
      * Create a CentreUser from a form
-     * @param AdminNewCentreUserRequest $request
-     * @return RedirectResponse
      * @throws Throwable
      */
     public function store(AdminNewCentreUserRequest $request): RedirectResponse
@@ -196,12 +185,13 @@ class CentreUsersController extends Controller
             // Throw it back to the user
             return redirect()->route('admin.centreusers.create')->withErrors('Creation failed - DB Error.');
         }
-        return redirect()->route('admin.centreusers.index')->with('message',
-            'Worker ' . $centreUser->name . ' created');
+        return redirect()->route('admin.centreusers.index')->with(
+            'message',
+            'Worker ' . $centreUser->name . ' created'
+        );
     }
 
     /**
-     * @return void
      * @throws CannotInsertRecord
      */
     public function download(): void
@@ -253,20 +243,18 @@ class CentreUsersController extends Controller
 
     /**
      * Handle deleting a centre user
-     * @param int $id
-     * @return RedirectResponse
      */
-    public function delete(int $id): RedirectResponse
+    public function retire(int $id): RedirectResponse
     {
         // must be disabled to delete
         $centreUser = CentreUser::onlyTrashed()->findOrFail($id);
         $name = $centreUser->name;
-        // remove any connections
-        $centreUser->centre->centreUsers()->detach($id);
+
         // boot them
-        $centreUser->forceDelete();
+        $centreUser->retire();
+
         return redirect()->route('admin.centreusers.index')
-            ->with('message', 'Worker ' . $name . ' deleted');
+            ->with('message', 'Worker ' . $name . ' retired');
     }
 
     /**

--- a/app/Traits/Retirable.php
+++ b/app/Traits/Retirable.php
@@ -58,6 +58,7 @@ trait Retirable
             array_merge($this->retirableFields(), ['retired_at' => now()])
         )->save();
 
+        // if we're not already soft deleted, do that too.
         $this->delete();
     }
 

--- a/app/Traits/Retirable.php
+++ b/app/Traits/Retirable.php
@@ -54,12 +54,15 @@ trait Retirable
             return;
         }
 
+        if (!$this->trashed()) {
+            throw new DomainException(
+                get_class($this) . " [$this->id] must be disabled before it can be retired."
+            );
+        }
+
         $this->forceFill(
             array_merge($this->retirableFields(), ['retired_at' => now()])
         )->save();
-
-        // if we're not already soft deleted, do that too.
-        $this->delete();
     }
 
     public function isRetired(): bool

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -63,6 +63,8 @@ $factory->define(App\CentreUser::class, function (Faker\Generator $faker) {
  * Relations (notes, centres) are preserved on the underlying row.
  */
 $factory->afterCreatingState(App\CentreUser::class, 'retired', function ($centreUser) {
+    // retired centres must be soft deleted first
+    $centreUser->delete();
     $centreUser->retire();
 });
 

--- a/resources/views/service/centreusers/edit.blade.php
+++ b/resources/views/service/centreusers/edit.blade.php
@@ -80,10 +80,10 @@
             <button type="submit" id="toggleWorker">@empty($worker->deleted_at)Disable worker @else Enable worker @endif</button>
         </form>
         @if($worker->deleted_at)
-        <form role="form" id="deleteForm" class="styled-form" method="GET"
-            action="{{ route('admin.centreusers.delete', ['id' => $worker->id]) }}">
+        <form role="form" id="retireForm" class="styled-form" method="GET"
+            action="{{ route('admin.centreusers.retire', ['id' => $worker->id]) }}">
             {!! csrf_field() !!}
-          <button type="submit" id="deleteWorker" class="remove">Delete worker</button>
+          <button type="submit" id="retireWorker" class="remove">Retire worker</button>
         </form>
         @endif
         <script>
@@ -175,12 +175,12 @@
                     // show the boxes when we load
                     buildCheckboxes();
                 });
-                $('#deleteWorker').on('click', function (evt) {
+                $('#retireWorker').on('click', function (evt) {
                   evt.preventDefault();
-                  var deleteForm = document.getElementById('deleteForm');
-                  var areYouSure = confirm('Are you sure you want to PERMANENTLY delete this worker account?');
+                  var retireForm = document.getElementById('retireForm');
+                  var areYouSure = confirm('Are you sure you want to PERMANENTLY retire this worker account?');
                   if (areYouSure === true) {
-                    deleteForm.submit();
+                    retireForm.submit();
                   };
                 });
         </script>

--- a/routes/service.php
+++ b/routes/service.php
@@ -121,9 +121,9 @@ Route::group(['middleware' => 'auth:admin'], function () {
         'uses' => 'Admin\CentreUsersController@toggle',
     ])->where('id', '^[0-9]+$');
 
-    Route::get('workers/{id}/delete', [
-        'as' => 'admin.centreusers.delete',
-        'uses' => 'Admin\CentreUsersController@delete',
+    Route::get('workers/{id}/retire', [
+        'as' => 'admin.centreusers.retire',
+        'uses' => 'Admin\CentreUsersController@retire',
     ])->where('id', '^[0-9]+$');
 
     // Centre Management

--- a/tests/Feature/Service/EditWorkerPageTest.php
+++ b/tests/Feature/Service/EditWorkerPageTest.php
@@ -13,14 +13,13 @@ class EditWorkerPageTest extends StoreTestCase
 {
     use RefreshDatabase;
 
-    /** @var AdminUser $adminUser */
-    private $adminUser;
+    private AdminUser $adminUser;
 
-    /** @var Centre $centre */
-    private $centre;
+    private Centre $centre;
 
-    /** @var Collection $altCentres */
-    private $altCentres;
+    private Collection $altCentres;
+
+    private CentreUser $worker;
 
     public function setUp(): void
     {
@@ -28,20 +27,21 @@ class EditWorkerPageTest extends StoreTestCase
         $this->adminUser = factory(AdminUser::class)->create();
         $this->centre = factory(Centre::class)->create([]);
         $this->altCentres = factory(Centre::class, 2)->create([]);
-    }
 
-    /**
-     * @return void
-     */
-    public function testItShowsAWorkerEditPage(): void
-    {
-        // Make a CentreUser from the data with 1 homeCentre.
-        $cu = factory(CentreUser::class)->create([
-            'name' => 'testman',
+        $this->worker = factory(CentreUser::class)->create([
+            'name'  => 'testman',
             'email' => 'testman@test.co.uk',
         ]);
-        $cu->centres()->attach($this->altCentres->last()->id, ['homeCentre' => true]);
-        $workerEditRoute = route('admin.centreusers.edit', ['id' => $cu->id,]);
+        $this->worker->centres()->attach($this->centre->id, ['homeCentre' => true]);
+    }
+
+    // -----------------------------------------------------------------------
+    // Page structure — active worker
+    // -----------------------------------------------------------------------
+
+    public function testItShowsAWorkerEditPage(): void
+    {
+        $workerEditRoute = route('admin.centreusers.edit', ['id' => $this->worker->id]);
 
         $this->actingAs($this->adminUser, 'admin')
             ->get($workerEditRoute)
@@ -57,6 +57,143 @@ class EditWorkerPageTest extends StoreTestCase
             ->seeElement('label[for="downloader"]')
             ->seeInElement('label[for="downloader"]', 'Downloader Status')
             ->seeElement('select[name="downloader"]')
+        ;
+    }
+
+    public function testActiveWorkerShowsUpdateButton(): void
+    {
+        $this->actingAs($this->adminUser, 'admin')
+            ->get(route('admin.centreusers.edit', ['id' => $this->worker->id]))
+            ->assertResponseOk()
+            ->seeElement('#updateWorker')
+        ;
+    }
+
+    public function testActiveWorkerShowsDisableButtonNotEnableButton(): void
+    {
+        $this->actingAs($this->adminUser, 'admin')
+            ->get(route('admin.centreusers.edit', ['id' => $this->worker->id]))
+            ->assertResponseOk()
+            ->seeInElement('#toggleWorker', 'Disable worker')
+            ->dontSeeInElement('#toggleWorker', 'Enable worker')
+        ;
+    }
+
+    public function testActiveWorkerDoesNotShowRetireForm(): void
+    {
+        $this->actingAs($this->adminUser, 'admin')
+            ->get(route('admin.centreusers.edit', ['id' => $this->worker->id]))
+            ->assertResponseOk()
+            ->dontSeeElement('#retireForm')
+            ->dontSeeElement('#retireWorker')
+        ;
+    }
+
+    public function testActiveWorkerDoesNotShowDisabledMessage(): void
+    {
+        $this->actingAs($this->adminUser, 'admin')
+            ->get(route('admin.centreusers.edit', ['id' => $this->worker->id]))
+            ->assertResponseOk()
+            ->dontSee('This worker is')
+        ;
+    }
+
+    public function testWorkerHomeCentreIsPreselectedInDropdown(): void
+    {
+        $this->actingAs($this->adminUser, 'admin')
+            ->get(route('admin.centreusers.edit', ['id' => $this->worker->id]))
+            ->assertResponseOk()
+            ->seeElement('option[value="' . $this->centre->id . '"][selected]')
+        ;
+    }
+
+    public function testWorkerAlternativeCentresAreRenderedAsOptions(): void
+    {
+        $this->worker->centres()->attach([
+            $this->altCentres[0]->id => ['homeCentre' => false],
+            $this->altCentres[1]->id => ['homeCentre' => false],
+        ]);
+
+        $this->actingAs($this->adminUser, 'admin')
+            ->get(route('admin.centreusers.edit', ['id' => $this->worker->id]))
+            ->assertResponseOk()
+            ->seeElement('option[value="' . $this->altCentres[0]->id . '"]')
+            ->seeElement('option[value="' . $this->altCentres[1]->id . '"]')
+        ;
+    }
+
+    // -----------------------------------------------------------------------
+    // Page structure — disabled (soft-deleted) worker
+    // -----------------------------------------------------------------------
+
+    public function testDisabledWorkerShowsDisabledMessage(): void
+    {
+        $this->worker->delete();
+
+        $this->actingAs($this->adminUser, 'admin')
+            ->get(route('admin.centreusers.edit', ['id' => $this->worker->id]))
+            ->assertResponseOk()
+            ->seeInElement('h2', 'This worker is')
+            ->seeInElement('h2 i', 'disabled')
+        ;
+    }
+
+    public function testDisabledWorkerDoesNotShowUpdateButton(): void
+    {
+        $this->worker->delete();
+
+        $this->actingAs($this->adminUser, 'admin')
+            ->get(route('admin.centreusers.edit', ['id' => $this->worker->id]))
+            ->assertResponseOk()
+            ->dontSeeElement('#updateWorker')
+        ;
+    }
+
+    public function testDisabledWorkerShowsEnableButtonNotDisableButton(): void
+    {
+        $this->worker->delete();
+
+        $this->actingAs($this->adminUser, 'admin')
+            ->get(route('admin.centreusers.edit', ['id' => $this->worker->id]))
+            ->assertResponseOk()
+            ->seeInElement('#toggleWorker', 'Enable worker')
+            ->dontSeeInElement('#toggleWorker', 'Disable worker')
+        ;
+    }
+
+    public function testDisabledWorkerShowsRetireForm(): void
+    {
+        $this->worker->delete();
+
+        $this->actingAs($this->adminUser, 'admin')
+            ->get(route('admin.centreusers.edit', ['id' => $this->worker->id]))
+            ->assertResponseOk()
+            ->seeElement('#retireForm')
+            ->seeElement('#retireWorker')
+        ;
+    }
+
+    public function testDisabledWorkerRetireFormPostsToCorrectRoute(): void
+    {
+        $this->worker->delete();
+
+        $this->actingAs($this->adminUser, 'admin')
+            ->get(route('admin.centreusers.edit', ['id' => $this->worker->id]))
+            ->assertResponseOk()
+            ->seeElement(
+                '#retireForm[action="' . route('admin.centreusers.retire', ['id' => $this->worker->id]) . '"]'
+            )
+        ;
+    }
+
+    // -----------------------------------------------------------------------
+    // Access control
+    // -----------------------------------------------------------------------
+
+    public function testUnauthenticatedUserCannotAccessEditPage(): void
+    {
+        $this->get(route('admin.centreusers.edit', ['id' => $this->worker->id]))
+            ->assertResponseStatus(302)
         ;
     }
 }

--- a/tests/Unit/Controllers/Service/Admin/CentreUserControllerTest.php
+++ b/tests/Unit/Controllers/Service/Admin/CentreUserControllerTest.php
@@ -46,8 +46,7 @@ class CentreUserControllerTest extends StoreTestCase
             ->assertResponseOk()
             ->seePageIs(route('admin.centreusers.index'))
             ->see($this->data["name"])
-            ->see($this->data["email"])
-        ;
+            ->see($this->data["email"]);
         // find the user
         $cu = CentreUser::where('email', $this->data['email'])->first();
         $this->assertNotNull($cu);
@@ -70,7 +69,7 @@ class CentreUserControllerTest extends StoreTestCase
         $this->seeInDatabase('centre_users', [
             'name' => $cu->name,
             'email' => $cu->email,
-            'downloader' => $cu->downloader
+            'downloader' => $cu->downloader,
         ]);
         // Check that worked.
         $this->assertCount(1, $cu->centres);
@@ -94,14 +93,12 @@ class CentreUserControllerTest extends StoreTestCase
             ->seeInDatabase('centre_users', [
                 'name' => $this->data['name'],
                 'email' => $this->data['email'],
-                'downloader' => $this->data['downloader']
+                'downloader' => $this->data['downloader'],
             ])
             ->dontSeeInDatabase('centre_users', [
                 'name' => $cu->name,
                 'email' => $cu->email,
-            ])
-        ;
-        ;
+            ]);
         // find the user
         $cu = CentreUser::where('email', $this->data['email'])->first();
         $this->assertNotNull($cu);
@@ -131,18 +128,16 @@ class CentreUserControllerTest extends StoreTestCase
             )
             ->followRedirects()
             ->assertResponseOk()
-            // returns to edit page
             ->seePageIs(route('admin.centreusers.edit', ['id' => $cu->id]))
-            // retains old information
+            // Centre pivot relations are preserved on disable.
             ->seeInDatabase('centre_centre_user', [
                 'centre_user_id' => $cu->id,
                 'centre_id' => $this->altCentres->last()->id,
-            ])
-            ->see('This worker is <i>disabled</i>')
-            ->seeInElement('#toggleWorker', ' Enable worker')
-            // There is a delete button
-            ->seeElement('#deleteWorker')
-        ;
+            ]);
+
+        // Record is soft-deleted but still present.
+        $this->assertNull(CentreUser::find($cu->id));
+        $this->assertNotNull(CentreUser::withTrashed()->find($cu->id)->deleted_at);
     }
 
     public function testItCanEnableACentreUser(): void
@@ -150,7 +145,7 @@ class CentreUserControllerTest extends StoreTestCase
         $cu = factory(CentreUser::class)->create([
             'name' => "testman",
             'email' => "testman@test.co.uk",
-            'deleted_at' => date("Y-m-d H:i:s")
+            'deleted_at' => date("Y-m-d H:i:s"),
         ]);
         $cu->centres()->attach($this->altCentres->last()->id, ['homeCentre' => true]);
 
@@ -166,16 +161,16 @@ class CentreUserControllerTest extends StoreTestCase
             )
             ->followRedirects()
             ->assertResponseOk()
-            // returns to edit page
             ->seePageIs(route('admin.centreusers.edit', ['id' => $cu->id]))
-            // retains old information
+            // Centre pivot relations are preserved on enable.
             ->seeInDatabase('centre_centre_user', [
                 'centre_user_id' => $cu->id,
                 'centre_id' => $this->altCentres->last()->id,
-            ])
-            ->dontSee('This worker is <i>disabled</i>')
-            ->seeInElement('#toggleWorker', 'Disable worker')
-        ;
+            ]);
+
+        // Record is restored and findable without withTrashed().
+        $this->assertNotNull(CentreUser::find($cu->id));
+        $this->assertNull(CentreUser::find($cu->id)->deleted_at);
     }
 
     public function testICanSeeDisabledCentreUsers(): void
@@ -183,20 +178,19 @@ class CentreUserControllerTest extends StoreTestCase
         $cu = factory(CentreUser::class)->create([
             'name' => "testman",
             'email' => "testman@test.co.uk",
-            'deleted_at' => date("Y-m-d H:i:s")
+            'deleted_at' => date("Y-m-d H:i:s"),
         ]);
 
         $this->seeInDatabase('centre_users', [
             'name' => $cu->name,
             'email' => $cu->email,
-            'deleted_at' => date("Y-m-d H:i:s")
+            'deleted_at' => date("Y-m-d H:i:s"),
         ]);
 
         $this->actingAs($this->adminUser, 'admin')
             ->visit(route('admin.centreusers.index'))
             ->assertResponseOk()
-            ->see($cu->email)
-        ;
+            ->see($cu->email);
     }
 
     public function testICannotSeeDeletedCentreUsers(): void
@@ -204,13 +198,13 @@ class CentreUserControllerTest extends StoreTestCase
         $cu = factory(CentreUser::class)->create([
             'name' => "testman",
             'email' => "testman@test.co.uk",
-            'deleted_at' => date("Y-m-d H:i:s")
+            'deleted_at' => date("Y-m-d H:i:s"),
         ]);
 
         $this->seeInDatabase('centre_users', [
             'name' => $cu->name,
             'email' => $cu->email,
-            'deleted_at' => date("Y-m-d H:i:s")
+            'deleted_at' => date("Y-m-d H:i:s"),
         ]);
 
         // remove it!
@@ -219,7 +213,76 @@ class CentreUserControllerTest extends StoreTestCase
         $this->actingAs($this->adminUser, 'admin')
             ->visit(route('admin.centreusers.index'))
             ->assertResponseOk()
-            ->dontSee($cu->email)
-        ;
+            ->dontSee($cu->email);
+    }
+
+    // -----------------------------------------------------------------------
+    // Retire action
+    // -----------------------------------------------------------------------
+
+    public function testRetiringADisabledWorkerWipesTheirPiiAndRedirectsToIndex(): void
+    {
+        $cu = factory(CentreUser::class)->create();
+        $cu->centres()->attach($this->centre->id, ['homeCentre' => true]);
+        $cu->delete();
+
+        $this->actingAs($this->adminUser, 'admin')
+            ->get(route('admin.centreusers.retire', ['id' => $cu->id]))
+            ->assertRedirectedToRoute('admin.centreusers.index')
+            ->assertSessionHas('message');
+
+        $retired = CentreUser::withTrashed()->find($cu->id);
+        $this->assertNotNull($retired->retired_at);
+        $this->assertSame('[User Retired]', $retired->name);
+        $this->assertStringStartsWith('retired_', $retired->email);
+        $this->assertStringEndsWith('@retired.invalid', $retired->email);
+    }
+
+    public function testRetiringADisabledWorkerRetainsTheirCentreRelations(): void
+    {
+        $cu = factory(CentreUser::class)->create();
+        $cu->centres()->attach($this->centre->id, ['homeCentre' => true]);
+        $cu->delete();
+
+        $this->actingAs($this->adminUser, 'admin')
+            ->get(route('admin.centreusers.retire', ['id' => $cu->id]));
+
+        $this->seeInDatabase('centre_centre_user', [
+            'centre_user_id' => $cu->id,
+            'centre_id' => $this->centre->id,
+        ]);
+    }
+
+    public function testRetiringAnActiveNonTrashedWorkerReturns404(): void
+    {
+        $cu = factory(CentreUser::class)->create();
+
+        $this->actingAs($this->adminUser, 'admin')
+            ->get(route('admin.centreusers.retire', ['id' => $cu->id]))
+            ->assertResponseStatus(404);
+    }
+
+    public function testRetiredWorkerCannotBeToggled(): void
+    {
+        $cu = factory(CentreUser::class)->create();
+        $cu->centres()->attach($this->centre->id, ['homeCentre' => true]);
+        $cu->delete();
+        $cu->retire();
+
+        $this->actingAs($this->adminUser, 'admin')
+            ->get(route('admin.centreusers.toggle', $cu->id));
+
+        // retired_at must still be set — the restoring event blocked the restore.
+        $this->assertNotNull(CentreUser::withTrashed()->find($cu->id)->retired_at);
+    }
+
+    public function testRetiredWorkerDoesNotAppearOnIndex(): void
+    {
+        $cu = factory(CentreUser::class)->state('retired')->create();
+
+        $this->actingAs($this->adminUser, 'admin')
+            ->visit(route('admin.centreusers.index'))
+            ->assertResponseOk()
+            ->dontSee($cu->email);
     }
 }

--- a/tests/Unit/Controllers/Service/Admin/CentreUserControllerTest.php
+++ b/tests/Unit/Controllers/Service/Admin/CentreUserControllerTest.php
@@ -137,7 +137,7 @@ class CentreUserControllerTest extends StoreTestCase
 
         // Record is soft-deleted but still present.
         $this->assertNull(CentreUser::find($cu->id));
-        $this->assertNotNull(CentreUser::withTrashed()->find($cu->id)->deleted_at);
+        $this->assertNotNull(CentreUser::withTrashed()->find($cu->id));
     }
 
     public function testItCanEnableACentreUser(): void

--- a/tests/Unit/Models/CentreUserModelTest.php
+++ b/tests/Unit/Models/CentreUserModelTest.php
@@ -70,9 +70,9 @@ class CentreUserModelTest extends TestCase
         $cu->centres()->attach($centre->id, ['homeCentre' => true]);
 
         // There is one
-        $this->assertEquals(1, $cu->centres()->count());
+        $this->assertSame(1, $cu->centres()->count());
         // It is the homeCentre
-        $this->assertEquals($centre->id, $cu->homeCentre->id);
+        $this->assertSame($centre->id, $cu->homeCentre->id);
     }
 
 
@@ -87,7 +87,7 @@ class CentreUserModelTest extends TestCase
         $cu->centres()->attach($centres->pluck('id')->all());
 
         // There is 4
-        $this->assertEquals(4, $cu->centres()->count());
+        $this->assertSame(4, $cu->centres()->count());
 
         // But We have no homeCentre
         $this->assertEmpty($cu->homeCentre);
@@ -110,16 +110,16 @@ class CentreUserModelTest extends TestCase
 
     public function testRetiredCentreUserHasNameCleared(): void
     {
-        $this->centreUser->retire();
+        $cu = factory(CentreUser::class)->state('retired')->create()->fresh();
 
-        $fresh = CentreUser::withTrashed()->find($this->centreUser->id);
-        $this->assertSame('[User Retired]', $fresh->name);
+        $this->assertSame('[User Retired]', $cu->name);
     }
 
     public function testRetiredCentreUserHasEmailReplacedWithSafeRetiredPlaceholder(): void
     {
         $originalEmail = $this->centreUser->email; // capture before retire() mutates the instance
 
+        $this->centreUser->delete();
         $this->centreUser->retire();
 
         $email = CentreUser::withTrashed()->find($this->centreUser->id)->email;
@@ -136,6 +136,7 @@ class CentreUserModelTest extends TestCase
     {
         $originalPassword = $this->centreUser->password; // capture before retire() mutates the instance
 
+        $this->centreUser->delete();
         $this->centreUser->retire();
 
         $replacedPassword = CentreUser::withTrashed()->find($this->centreUser->id)->password;
@@ -146,10 +147,9 @@ class CentreUserModelTest extends TestCase
 
     public function testRetiredCentreUserHasRememberTokenCleared(): void
     {
-        $this->centreUser->retire();
+        $cu = factory(CentreUser::class)->state('retired')->create()->fresh();
 
-        $fresh = CentreUser::withTrashed()->find($this->centreUser->id);
-        $this->assertNull($fresh->remember_token);
+        $this->assertNull($cu->remember_token);
     }
 
     public function testRetiredCentreUserRetainsNoteRelations(): void
@@ -157,6 +157,7 @@ class CentreUserModelTest extends TestCase
         // Notes exist before retirement.
         $this->assertCount(2, $this->centreUser->notes);
 
+        $this->centreUser->delete();
         $this->centreUser->retire();
 
         // Notes are still associated via FK after retirement.
@@ -169,10 +170,11 @@ class CentreUserModelTest extends TestCase
         $centre = factory(Centre::class)->create();
         $this->centreUser->centres()->attach($centre->id, ['homeCentre' => true]);
 
+        $this->centreUser->delete();
         $this->centreUser->retire();
 
         $fresh = CentreUser::withTrashed()->find($this->centreUser->id);
-        $this->assertEquals(1, $fresh->centres()->count());
+        $this->assertSame(1, $fresh->centres()->count());
     }
 
     public function testRetiredCentreUserCannotBeRestored(): void

--- a/tests/Unit/Traits/RetirableTest.php
+++ b/tests/Unit/Traits/RetirableTest.php
@@ -101,9 +101,20 @@ class RetirableTest extends TestCase
     // -----------------------------------------------------------------------
 
 
+    public function testRetireThrowsDomainExceptionIfModelIsNotSoftDeleted(): void
+    {
+        $stub = $this->makeStub();
+
+        $this->expectException(DomainException::class);
+        $this->expectExceptionMessage('must be disabled before it can be retired');
+
+        $stub->retire();
+    }
+
     public function testRetireSetsRetiredAtToCurrentTime(): void
     {
         $stub = $this->makeStub();
+        $stub->delete();
 
         $stub->retire();
 
@@ -111,19 +122,10 @@ class RetirableTest extends TestCase
     }
 
 
-    public function testRetireSoftDeletesTheModel(): void
-    {
-        $stub = $this->makeStub();
-
-        $stub->retire();
-
-        $this->assertSoftDeleted('retirable_stubs', ['id' => $stub->id]);
-    }
-
-
     public function testRetireReplacesEachFieldDeclaredInRetirableFields(): void
     {
         $stub = $this->makeStub();
+        $stub->delete();
         $originalEmail = $stub->email;
         $originalPassword = $stub->password;
 
@@ -140,6 +142,7 @@ class RetirableTest extends TestCase
     public function testRetireStoresAValidEmailPlaceholder(): void
     {
         $stub = $this->makeStub();
+        $stub->delete();
 
         $stub->retire();
 
@@ -153,6 +156,7 @@ class RetirableTest extends TestCase
     public function testRetireStoresAHashedPasswordNotPlainText(): void
     {
         $stub = $this->makeStub();
+        $stub->delete();
 
         $stub->retire();
 
@@ -165,6 +169,7 @@ class RetirableTest extends TestCase
     public function testRetireIsIdempotentAndDoesNotChangeFieldsOnSecondCall(): void
     {
         $stub = $this->makeStub();
+        $stub->delete();
         $stub->retire();
 
         $afterFirst = TestRetirableModel::withTrashed()->find($stub->id);
@@ -185,7 +190,9 @@ class RetirableTest extends TestCase
         $first = $this->makeStub(['email' => 'first@example.com']);
         $second = $this->makeStub(['email' => 'second@example.com']);
 
+        $first->delete();
         $first->retire();
+        $second->delete();
         $second->retire();
 
         $emailFirst = TestRetirableModel::withTrashed()->find($first->id)->email;
@@ -210,6 +217,7 @@ class RetirableTest extends TestCase
     public function testIsRetiredReturnsTrueAfterRetirement(): void
     {
         $stub = $this->makeStub();
+        $stub->delete();
 
         $stub->retire();
 
@@ -224,6 +232,7 @@ class RetirableTest extends TestCase
     public function testRestoringARetiredModelThrowsADomainException(): void
     {
         $stub = $this->makeStub();
+        $stub->delete();
         $stub->retire();
 
         $this->expectException(DomainException::class);
@@ -255,6 +264,7 @@ class RetirableTest extends TestCase
         $retired = $this->makeStub(['email' => 'retired@example.com']);
 
         $deleted->delete();
+        $retired->delete();
         $retired->retire();
 
         $results = TestRetirableModel::retired()->get();
@@ -271,6 +281,7 @@ class RetirableTest extends TestCase
         $retired = $this->makeStub(['email' => 'retired@example.com']);
 
         $deleted->delete();
+        $retired->delete();
         $retired->retire();
 
         $results = TestRetirableModel::active()->get();


### PR DESCRIPTION
https://trello.com/c/ytZJt1yn/2189-bug-permenently-deleting-a-centre-user-ee-vv

- converted the delete function in the controller to a retire function
- since we're not deleting any more we keep the relations
- updated the edit page to be "reitre" not "delete"
- updated the route name to be "retire" not "delete"
- updated a whole bunch of tests