### PR TITLE
1.20/2254 amend centres so they can be set to collect vouchers eee vvv part 2 UI

### DIFF
--- a/app/Http/Controllers/Service/Admin/CentresController.php
+++ b/app/Http/Controllers/Service/Admin/CentresController.php
@@ -6,96 +6,73 @@ use App\Centre;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\AdminNewCentreRequest;
 use App\Http\Requests\AdminUpdateCentreRequest;
-use Auth;
-use DB;
-use Exception;
-use Illuminate\Contracts\View\Factory;
+use App\Sponsor;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Illuminate\View\View;
-use App\Sponsor;
-use Log;
+use Throwable;
 
 class CentresController extends Controller
 {
-
     /**
      * Display a listing of Centres.
-     *
-     * @return Factory|View
      */
-    public function index()
+    public function index(): View
     {
-        $centres = Centre::get();
+        $centres = Centre::all();
 
         return view('service.centres.index', compact('centres'));
     }
 
     /**
      * Show the form for creating new Centres.
-     *
-     * @return Factory|View
      */
-    public function create()
+    public function create(): View
     {
-        $sponsors = Sponsor::get();
+        $sponsors = Sponsor::all();
 
         return view('service.centres.create', compact('sponsors'));
     }
 
     /**
-     * Return a json list of neighbour names and IDs
-     *
-     * @param $id
-     * @return JsonResponse
+     * Return a JSON list of neighbour names and IDs.
      */
-    public function getNeighboursAsJson($id)
+    public function getNeighboursAsJson(int $id): JsonResponse
     {
         try {
-            /** @var Centre $centre */
-            $centre = Centre::findOrFail($id);
-            $neighbours = $centre
+            $neighbours = Centre::findOrFail($id)
                 ->neighbours()
                 ->whereKeyNot($id)
-                ->get(['name', 'id'])
-            ;
-        } catch (ModelNotFoundException $e) {
-            $neighbours = collect([]);
+                ->get(['name', 'id']);
+        } catch (ModelNotFoundException) {
+            $neighbours = collect();
         }
+
         return response()->json($neighbours);
     }
 
     /**
-     * @param AdminNewCentreRequest $request
-     * @return RedirectResponse
-     * @throws \Throwable
+     * Store a newly created Centre.
      */
-    public function store(AdminNewCentreRequest $request)
+    public function store(AdminNewCentreRequest $request): RedirectResponse
     {
         try {
-            $centre = DB::transaction(function () use ($request) {
-
-                // Create a Centre
-                $c = new Centre([
-                    'name' => $request->input('name'),
-                    'prefix' => $request->input('rvid_prefix'),
-                    'print_pref' => $request->input('print_pref'),
-                    'sponsor_id' => $request->input('sponsor')
-                ]);
-                $c->save();
-
-                return $c;
+            $centre = DB::transaction(static function () use ($request): Centre {
+                return Centre::create($request->validated());
             });
-        } catch (Exception $e) {
-            // Oops! Log that
+        } catch (Throwable $e) {
             Log::error('Bad transaction for ' . __CLASS__ . '@' . __METHOD__ . ' by service user ' . Auth::id());
             Log::error($e->getTraceAsString());
-            // Throw it back to the user
+
             return redirect()
                 ->route('admin.centres.create')
                 ->withErrors('Creation failed - DB Error.');
         }
+
         return redirect()
             ->route('admin.centres.index')
             ->with('message', 'Centre ' . $centre->name . ' created');
@@ -103,43 +80,37 @@ class CentresController extends Controller
 
     /**
      * Show the form for editing a Centre.
-     *
-     * @return Factory|View
      */
-    public function edit($id)
+    public function edit(Centre $centre): View
     {
-        $centre = Centre::find($id);
         return view('service.centres.edit', compact('centre'));
     }
 
     /**
-     * Show the form for editing a Centre's name.
-     *
-     * @return Factory|View
+     * Update the specified Centre's name.
      */
-    public function update(AdminUpdateCentreRequest $request, Centre $id)
+    public function update(AdminUpdateCentreRequest $request, Centre $centre): RedirectResponse
     {
-      try {
-          $centre = DB::transaction(function () use ($request, $id) {
-            // Update the system
-            $id->fill([
-                'name' => $request->input('name'),
-            ]);
-              $id->save();
+        try {
+            $centre = DB::transaction(static function () use ($request, $centre): Centre {
+                $centre->fill([
+                    'name' => $request->input('name'),
+                ]);
+                $centre->save();
 
-              return $id;
-          });
-      } catch (Exception $e) {
-          // Oops! Log that
-          Log::error('Bad transaction for ' . __CLASS__ . '@' . __METHOD__ . ' by service user ' . Auth::id());
-          Log::error($e->getTraceAsString());
-          // Throw it back to the user
-          return redirect()
-              ->route('admin.centres.create')
-              ->withErrors('Creation failed - DB Error.');
-      }
-      return redirect()
-          ->route('admin.centres.index')
-          ->with('message', 'Centre ' . $centre->name . ' edited');
+                return $centre;
+            });
+        } catch (Throwable $e) {
+            Log::error('Bad transaction for ' . __CLASS__ . '@' . __METHOD__ . ' by service user ' . Auth::id());
+            Log::error($e->getTraceAsString());
+
+            return redirect()
+                ->route('admin.centres.edit', $centre)
+                ->withErrors('Update failed - DB Error.');
+        }
+
+        return redirect()
+            ->route('admin.centres.index')
+            ->with('message', 'Centre ' . $centre->name . ' edited');
     }
 }

--- a/app/Http/Controllers/Service/Admin/CentresController.php
+++ b/app/Http/Controllers/Service/Admin/CentresController.php
@@ -7,7 +7,6 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\AdminNewCentreRequest;
 use App\Http\Requests\AdminUpdateCentreRequest;
 use App\Sponsor;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Auth;
@@ -41,16 +40,12 @@ class CentresController extends Controller
     /**
      * Return a JSON list of neighbour names and IDs.
      */
-    public function getNeighboursAsJson(int $id): JsonResponse
+    public function getNeighboursAsJson(Centre $centre): JsonResponse
     {
-        try {
-            $neighbours = Centre::findOrFail($id)
-                ->neighbours()
-                ->whereKeyNot($id)
-                ->get(['name', 'id']);
-        } catch (ModelNotFoundException) {
-            $neighbours = collect();
-        }
+        $neighbours = $centre
+            ->neighbours()
+            ->whereKeyNot($centre->getKey())
+            ->get(['name', 'id']);
 
         return response()->json($neighbours);
     }
@@ -83,22 +78,18 @@ class CentresController extends Controller
      */
     public function edit(Centre $centre): View
     {
-        return view('service.centres.edit', compact('centre'));
+        $sponsors = Sponsor::all();
+        return view('service.centres.edit', compact('centre', 'sponsors'));
     }
 
     /**
-     * Update the specified Centre's name.
+     * Update the specified Centre's fields
      */
     public function update(AdminUpdateCentreRequest $request, Centre $centre): RedirectResponse
     {
         try {
-            $centre = DB::transaction(static function () use ($request, $centre): Centre {
-                $centre->fill([
-                    'name' => $request->input('name'),
-                ]);
-                $centre->save();
-
-                return $centre;
+            DB::transaction(static function () use ($request, $centre): bool {
+                return $centre->update($request->validated());
             });
         } catch (Throwable $e) {
             Log::error('Bad transaction for ' . __CLASS__ . '@' . __METHOD__ . ' by service user ' . Auth::id());

--- a/app/Http/Controllers/Service/Admin/CentresController.php
+++ b/app/Http/Controllers/Service/Admin/CentresController.php
@@ -105,7 +105,7 @@ class CentresController extends Controller
             Log::error($e->getTraceAsString());
 
             return redirect()
-                ->route('admin.centres.edit', $centre)
+                ->route('admin.centres.edit', $centre->id)
                 ->withErrors('Update failed - DB Error.');
         }
 

--- a/app/Http/Requests/AdminNewCentreRequest.php
+++ b/app/Http/Requests/AdminNewCentreRequest.php
@@ -4,7 +4,6 @@ namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
-use App\Rules\NotExistsRule;
 
 class AdminNewCentreRequest extends FormRequest
 {
@@ -13,49 +12,67 @@ class AdminNewCentreRequest extends FormRequest
      *
      * @return bool
      */
-    public function authorize()
+    public function authorize(): bool
     {
         // Covered by Admin user auth
         return true;
     }
 
     /**
-     * Get the validation rules that apply to the request.
-     *
-     * @return array
+     * Normalise input before validation runs.
      */
-    public function rules()
+    public function prepareForValidation(): void
+    {
+        $this->merge([
+            'can_collect' => $this->boolean('can_collect'),
+            'prefix' => strtoupper((string)$this->input('prefix', '')),
+        ]);
+    }
+
+    /**
+     * Validation rules
+     */
+    public function rules(): array
     {
         return [
-            // MUST be present, string
-            'name' => 'required|string',
-            // MUST be present, integer, in table
-            'sponsor' => 'required|integer|exists:sponsors,id',
-            // MUST be present, string, 1-5 characters and not in use
-            'rvid_prefix' => [
+            'name' => ['required', 'string'],
+            'sponsor_id' => ['required', 'exists:sponsors,id'],
+            'prefix' => [
                 'required',
                 'string',
                 'between:1,5',
-                new NotExistsRule('centres', 'prefix'),
+                Rule::unique('centres', 'prefix'),
             ],
-            // MUST be present, in print_prefs
             'print_pref' => [
                 'required',
-                Rule::in(config('arc.print_preferences'))
-            ]
+                Rule::in(config('arc.print_preferences')),
+            ],
+            'can_collect' => ['nullable', 'boolean']
         ];
     }
 
     /**
-     * Prep input for validation
+     * Human-readable attribute names used in error messages.
      */
-    public function prepareForValidation()
+    public function attributes(): array
     {
-        if ($this->has('rvid_prefix')) {
-            $this->merge(
-                // In this system, we're want it uppercase
-                ['rvid_prefix' => strtoupper($this->input('rvid_prefix'))]
-            );
-        }
+        return [
+            'sponsor_id' => 'sponsor',
+            'prefix' => 'RVID prefix',
+            'print_pref' => 'print preference',
+            'can-collect' => 'collection',
+        ];
+    }
+
+    /**
+     * Custom error messages.
+     */
+    public function messages(): array
+    {
+        return [
+            'prefix.unique' => 'That RVID prefix is already in use.',
+            'prefix.between' => 'The RVID prefix must be between 1 and 5 characters.',
+            'print_pref.in' => 'The selected print preference is not valid.',
+        ];
     }
 }

--- a/app/Http/Requests/AdminNewCentreRequest.php
+++ b/app/Http/Requests/AdminNewCentreRequest.php
@@ -35,13 +35,13 @@ class AdminNewCentreRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'name' => ['required', 'string'],
+            'name' => ['required', 'string', 'unique:centres,name'],
             'sponsor_id' => ['required', 'exists:sponsors,id'],
             'prefix' => [
                 'required',
                 'string',
                 'between:1,5',
-                Rule::unique('centres', 'prefix'),
+                'unique:centres,prefix',
             ],
             'print_pref' => [
                 'required',
@@ -70,6 +70,7 @@ class AdminNewCentreRequest extends FormRequest
     public function messages(): array
     {
         return [
+            'name.unique' => 'That name is already in use.',
             'prefix.unique' => 'That RVID prefix is already in use.',
             'prefix.between' => 'The RVID prefix must be between 1 and 5 characters.',
             'print_pref.in' => 'The selected print preference is not valid.',

--- a/app/Http/Requests/AdminUpdateCentreRequest.php
+++ b/app/Http/Requests/AdminUpdateCentreRequest.php
@@ -3,29 +3,79 @@
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class AdminUpdateCentreRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.
-     *
-     * @return bool
      */
-    public function authorize()
+    public function authorize(): bool
     {
         return true;
     }
 
     /**
-     * Get the validation rules that apply to the request.
-     *
-     * @return array
+     * Normalise input before validation runs.
      */
-    public function rules()
+    public function prepareForValidation(): void
     {
-      return [
-          'id' => 'required|integer|exists:centres,id',
-          'name' => 'required|string',
-      ];
+        $this->merge([
+            'can_collect' => $this->boolean('can_collect'),
+            'prefix' => strtoupper((string)$this->input('prefix', '')),
+        ]);
+    }
+
+    /**
+     * Validation rules
+     */
+    public function rules(): array
+    {
+        $centreId = $this->route('centre')?->id;
+        return [
+            'name' => [
+                'required',
+                'string',
+                Rule::unique('centres', 'name')->ignore($centreId),
+            ],
+            'sponsor_id' => ['required', 'exists:sponsors,id'],
+            'prefix' => [
+                'required',
+                'string',
+                'between:1,5',
+                Rule::unique('centres', 'prefix')->ignore($centreId),
+            ],
+            'print_pref' => [
+                'required',
+                Rule::in(config('arc.print_preferences')),
+            ],
+            'can_collect' => ['nullable', 'boolean']
+        ];
+    }
+
+    /**
+     * Human-readable attribute names used in error messages.
+     */
+    public function attributes(): array
+    {
+        return [
+            'sponsor_id' => 'sponsor',
+            'prefix' => 'RVID prefix',
+            'print_pref' => 'print preference',
+            'can-collect' => 'collection',
+        ];
+    }
+
+    /**
+     * Custom error messages.
+     */
+    public function messages(): array
+    {
+        return [
+            'name.unique' => 'That name is already in use.',
+            'prefix.unique' => 'That RVID prefix is already in use.',
+            'prefix.between' => 'The RVID prefix must be between 1 and 5 characters.',
+            'print_pref.in' => 'The selected print preference is not valid.',
+        ];
     }
 }

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -96,7 +96,7 @@ h1 {
 
   .checkbox-group {
     position: relative;
-    padding-left: 55px;
+    padding-left: 2.5rem;
     margin: 0.5rem 0 2rem 0;
     min-height: 10px;
 
@@ -107,20 +107,20 @@ h1 {
       &:checked + label:after {
         content: '✔';
         position: absolute;
-        top: 6px;
-        left: 12px;
+        left: 0.75rem;
+        top: 0;
         border: 0;
       }
     }
     > label {
       cursor: pointer;
-      margin-left: -20px;
+      line-height: 2.5rem;
 
       &:before {
         content: '';
         background: #ffffff;
-        width: 34px;
-        height: 34px;
+        width: 2.5rem;
+        height: 2.5rem;
         border: 1px solid #ececec;
         position: absolute;
         left: 0;

--- a/resources/views/service/centres/create.blade.php
+++ b/resources/views/service/centres/create.blade.php
@@ -68,16 +68,16 @@
                             @endforeach
                         </select>
                     </div>
-                    <div class="checkbox-group">
-                        <input type="checkbox"
-                               id="can-collect"
-                               name="can-collect"
-                               class="styled-checkbox @error('can-collect') error @enderror"
-                               @checked(old('can-collect', $centre?->can_collect))
-                        >
-                        <label for="can-collect">Can Collect Vouchers</label>
-                        @include('service.partials.validationMessages', ['inputName' => 'can-collect'])
-                    </div>
+                </div>
+                <div class="checkbox-group">
+                    <input type="checkbox"
+                           id="can-collect"
+                           name="can-collect"
+                           class="styled-checkbox @error('can-collect') error @enderror"
+                        @checked(old('can-collect') === true)
+                    >
+                    <label for="can-collect">Can Collect Vouchers</label>
+                    @include('service.partials.validationMessages', ['inputName' => 'can-collect'])
                 </div>
                 <button type="submit" id="createCentre">Save</button>
             </form>

--- a/resources/views/service/centres/create.blade.php
+++ b/resources/views/service/centres/create.blade.php
@@ -1,50 +1,87 @@
 @extends('service.layouts.app')
 @section('content')
 
-<div id="container">
-    @include('service.includes.sidebar')
-    <div id="main-content">
+    <div id="container">
+        @include('service.includes.sidebar')
+        <div id="main-content">
 
-        <h1>Add a Children's Centre</h1>
+            <h1>Add a Children's Centre</h1>
 
-        <p>Use the form below to add a new children's centre. Add their name, RVID prefix, area and form.</p>
+            <p>Use the form below to add a new children's centre. Add their name, RVID prefix, area and form.</p>
 
-        <form role="form" class="styled-form" method="POST" action="{{ route('admin.centres.store') }}">
-            {!! csrf_field() !!}
-            <div class="horizontal-container">
-                <div>
-                    <label for="name" class="required">Name</label>
-                    <input type="text" id="name" name="name" class="{{ $errors->has('name') ? 'error' : '' }}" required>
-                    @include('service.partials.validationMessages', array('inputName' => 'name'))
+            <form class="styled-form"
+                  method="POST"
+                  action="{{ route('admin.centres.store') }}"
+            >
+                @csrf
+                <div class="horizontal-container">
+                    <div>
+                        <label for="name" class="required">Name</label>
+                        <input type="text"
+                               id="name"
+                               name="name"
+                               class="@error('name') error @enderror"
+                               value="{{ old('name') }}"
+                               required
+                        >
+                        @include('service.partials.validationMessages', ['inputName' => 'name'])
+                    </div>
+                    <div>
+                        <label for="rvid_prefix" class="required">RVID prefix</label>
+                        <input type="text"
+                               id="rvid_prefix"
+                               name="rvid_prefix"
+                               class="@error('rvid_prefix') error @enderror uppercase"
+                               value="{{ old('rvid_prefix') }}"
+                               required
+                        >
+                        @include('service.partials.validationMessages', ['inputName' => 'rvid_prefix'])
+                    </div>
+                    <div class="select">
+                        <label for="sponsor">Area</label>
+                        <select name="sponsor"
+                                id="sponsor"
+                                class="@error('sponsor') error @enderror"
+                                required
+                        >
+                            <option value="">Choose one</option>
+                            @foreach ($sponsors as $sponsor)
+                                <option value="{{ $sponsor->id }}"
+                                        @selected(old('sponsor') === $sponsor->id)
+                                >{{ $sponsor->name }}</option>
+                            @endforeach
+                        </select>
+                        @include('service.partials.validationMessages', ['inputName' => 'sponsor'])
+                    </div>
+                    <div class="select">
+                        <label for="print_pref">Printed Form</label>
+                        <select name="print_pref"
+                                id="print_pref"
+                                class="@error('print_pref') error @enderror"
+                                required
+                        >
+                            <option value="" disabled>Choose one</option>
+                            @foreach (config('arc.print_preferences') as $pref)
+                                <option value="{{ $pref }}"
+                                        @selected(old('print_pref', 'collection') === 'pref')
+                                >{{ ucwords($pref) }}</option>
+                            @endforeach
+                        </select>
+                    </div>
+                    <div class="checkbox-group">
+                        <input type="checkbox"
+                               id="can-collect"
+                               name="can-collect"
+                               class="styled-checkbox @error('can-collect') error @enderror"
+                               @checked(old('can-collect', $centre?->can_collect))
+                        >
+                        <label for="can-collect">Can Collect Vouchers</label>
+                        @include('service.partials.validationMessages', ['inputName' => 'can-collect'])
+                    </div>
                 </div>
-                <div>
-                    <label for="rvid_prefix" class="required">RVID prefix</label>
-                    <input type="text" id="rvid_prefix" name="rvid_prefix" class="{{ $errors->has('rvid_prefix') ? 'error ' : '' }} uppercase" required>
-                    @include('service.partials.validationMessages', array('inputName' => 'rvid_prefix'))
-                </div>
-                <div class="select">
-                    <label for="sponsor">Area</label>
-                    <select name="sponsor" id="sponsor" class="{{ $errors->has('sponsor') ? 'error' : '' }}" required>
-                        <option value="">Choose one</option>
-                        @foreach ($sponsors as $sponsor)
-                            <option value="{{ $sponsor->id }}">{{ $sponsor->name }}</option>
-                        @endforeach
-                    </select>
-                    @include('service.partials.validationMessages', array('inputName' => 'sponsor'))
-                </div>
-                <div class="select">
-                    <label for="print_pref">Printed Form</label>
-                    <select name="print_pref" id="print_pref" class="{{ $errors->has('print_pref') ? 'error' : '' }}" required>
-                        <option value="" disabled>Choose one</option>
-                        @foreach (config('arc.print_preferences') as $pref)
-                            <option value="{{ $pref }}" {{$pref == 'collection' ? 'selected' : ''}} >{{ ucwords($pref) }}</option>
-                        @endforeach
-                    </select>
-                </div>
-            </div>
-            <button type="submit" id="createSponsor">Save</button>
-        </form>
+                <button type="submit" id="createCentre">Save</button>
+            </form>
+        </div>
     </div>
-</div>
 
 @endsection

--- a/resources/views/service/centres/create.blade.php
+++ b/resources/views/service/centres/create.blade.php
@@ -27,31 +27,31 @@
                         @include('service.partials.validationMessages', ['inputName' => 'name'])
                     </div>
                     <div>
-                        <label for="rvid_prefix" class="required">RVID prefix</label>
+                        <label for="prefix" class="required">RVID prefix</label>
                         <input type="text"
-                               id="rvid_prefix"
-                               name="rvid_prefix"
-                               class="@error('rvid_prefix') error @enderror uppercase"
-                               value="{{ old('rvid_prefix') }}"
+                               id="prefix"
+                               name="prefix"
+                               class="@error('prefix') error @enderror uppercase"
+                               value="{{ old('prefix') }}"
                                required
                         >
-                        @include('service.partials.validationMessages', ['inputName' => 'rvid_prefix'])
+                        @include('service.partials.validationMessages', ['inputName' => 'prefix'])
                     </div>
                     <div class="select">
-                        <label for="sponsor">Area</label>
-                        <select name="sponsor"
-                                id="sponsor"
-                                class="@error('sponsor') error @enderror"
+                        <label for="sponsor_id">Area</label>
+                        <select name="sponsor_id"
+                                id="sponsor_id"
+                                class="@error('sponsor_id') error @enderror"
                                 required
                         >
                             <option value="">Choose one</option>
                             @foreach ($sponsors as $sponsor)
                                 <option value="{{ $sponsor->id }}"
-                                        @selected(old('sponsor') === $sponsor->id)
+                                        @selected(old('sponsor_id') === $sponsor->id)
                                 >{{ $sponsor->name }}</option>
                             @endforeach
                         </select>
-                        @include('service.partials.validationMessages', ['inputName' => 'sponsor'])
+                        @include('service.partials.validationMessages', ['inputName' => 'sponsor_id'])
                     </div>
                     <div class="select">
                         <label for="print_pref">Printed Form</label>
@@ -71,13 +71,13 @@
                 </div>
                 <div class="checkbox-group">
                     <input type="checkbox"
-                           id="can-collect"
-                           name="can-collect"
-                           class="styled-checkbox @error('can-collect') error @enderror"
-                        @checked(old('can-collect') === true)
+                           id="can_collect"
+                           name="can_collect"
+                           class="styled-checkbox @error('can_collect') error @enderror"
+                           @checked(old('can_collect') === true)
                     >
-                    <label for="can-collect">Can Collect Vouchers</label>
-                    @include('service.partials.validationMessages', ['inputName' => 'can-collect'])
+                    <label for="can_collect">Can Collect Vouchers</label>
+                    @include('service.partials.validationMessages', ['inputName' => 'can_collect'])
                 </div>
                 <button type="submit" id="createCentre">Save</button>
             </form>

--- a/resources/views/service/centres/create.blade.php
+++ b/resources/views/service/centres/create.blade.php
@@ -7,7 +7,7 @@
 
             <h1>Add a Children's Centre</h1>
 
-            <p>Use the form below to add a new children's centre. Add their name, RVID prefix, area and form.</p>
+            <p>Use the form below to add a new children's centre. Add their name, RVID prefix, area, form style and collecting state</p>
 
             <form class="styled-form"
                   method="POST"

--- a/resources/views/service/centres/edit.blade.php
+++ b/resources/views/service/centres/edit.blade.php
@@ -80,7 +80,7 @@
                     <label for="can_collect">Can Collect Vouchers</label>
                     @include('service.partials.validationMessages', ['inputName' => 'can_collect'])
                 </div>
-                <button type="submit" id="createCentre">Save</button>
+                <button type="submit" id="updateCentre">Save</button>
             </form>
         </div>
     </div>

--- a/resources/views/service/centres/edit.blade.php
+++ b/resources/views/service/centres/edit.blade.php
@@ -1,42 +1,88 @@
 @extends('service.layouts.app')
 @section('content')
 
-<div id="container">
-    @include('service.includes.sidebar')
-    <div id="main-content">
-        <h1>{{ $centre->name }}</h1>
-        @if (Session::get('message'))
-            <div class="alert alert-success">
-                {{ Session::get('message') }}
-            </div>
-        @endif
-        <form role="form" method="POST" action="{{ route('admin.centres.update', ['id' => $centre->id]) }}">
-          @method('put')
-          @csrf
-          <input type="hidden" id="id" name="id" value="{{ $centre->id }}">
-          <table class="table table-striped">
-              <thead>
-                  <tr>
-                      <th>Name</th>
-                      <th>RVID Prefix</th>
-                      <th>Area</th>
-                      <th>Form</th>
-                      <th>Save</th>
-                  </tr>
-              </thead>
-              <tbody>
-                  <tr>
-                      <td><input type="text" id="name" name="name" value="{{ $centre->name ?? '' }}"
-                        class="{{ $errors->has('name') ? 'has-error' : '' }}" required>
-                      </td>
-                      <td>{{ $centre->prefix }}</td>
-                      <td>{{ $centre->sponsor->name }}</td>
-                      <td>{{ ucwords($centre->print_pref) }}</td>
-                      <td><button type="submit" id="save">Save</button></td>
-                  </tr>
-              </tbody>
-          </table>
-      </form>
+    <div id="container">
+        @include('service.includes.sidebar')
+        <div id="main-content">
+
+            <h1>Edit Children's Centre</h1>
+
+            <p>Use the form below to edit this children's centre. Update their name, RVID prefix, area, form style and collecting state</p>
+
+            <form class="styled-form"
+                  method="POST"
+                  action="{{ route('admin.centres.update', $centre) }}"
+            >
+                @csrf
+                @method('PUT')
+                <div class="horizontal-container">
+                    <div>
+                        <label for="name" class="required">Name</label>
+                        <input type="text"
+                               id="name"
+                               name="name"
+                               class="@error('name') error @enderror"
+                               value="{{ old('name', $centre->name) }}"
+                               required
+                        >
+                        @include('service.partials.validationMessages', ['inputName' => 'name'])
+                    </div>
+                    <div>
+                        <label for="prefix" class="required">RVID prefix</label>
+                        <input type="text"
+                               id="prefix"
+                               name="prefix"
+                               class="@error('prefix') error @enderror uppercase"
+                               value="{{ old('prefix', $centre->prefix) }}"
+                               required
+                        >
+                        @include('service.partials.validationMessages', ['inputName' => 'prefix'])
+                    </div>
+                    <div class="select">
+                        <label for="sponsor_id">Area</label>
+                        <select name="sponsor_id"
+                                id="sponsor_id"
+                                class="@error('sponsor_id') error @enderror"
+                                required
+                        >
+                            <option value="">Choose one</option>
+                            @foreach ($sponsors as $sponsor)
+                                <option value="{{ $sponsor->id }}"
+                                    @selected(old('sponsor_id', $centre->sponsor_id) === $sponsor->id)
+                                >{{ $sponsor->name }}</option>
+                            @endforeach
+                        </select>
+                        @include('service.partials.validationMessages', ['inputName' => 'sponsor_id'])
+                    </div>
+                    <div class="select">
+                        <label for="print_pref">Printed Form</label>
+                        <select name="print_pref"
+                                id="print_pref"
+                                class="@error('print_pref') error @enderror"
+                                required
+                        >
+                            <option value="" disabled>Choose one</option>
+                            @foreach (config('arc.print_preferences') as $pref)
+                                <option value="{{ $pref }}"
+                                    @selected(old('print_pref', $centre->print_pref) === $pref)
+                                >{{ ucwords($pref) }}</option>
+                            @endforeach
+                        </select>
+                    </div>
+                </div>
+                <div class="checkbox-group">
+                    <input type="checkbox"
+                           id="can_collect"
+                           name="can_collect"
+                           class="styled-checkbox @error('can_collect') error @enderror"
+                        @checked(old('can_collect', $centre->can_collect))
+                    >
+                    <label for="can_collect">Can Collect Vouchers</label>
+                    @include('service.partials.validationMessages', ['inputName' => 'can_collect'])
+                </div>
+                <button type="submit" id="createCentre">Save</button>
+            </form>
+        </div>
     </div>
-</div>
+
 @endsection

--- a/resources/views/service/centres/index.blade.php
+++ b/resources/views/service/centres/index.blade.php
@@ -30,7 +30,7 @@
                         <td>{{ $centre->sponsor->name }}</td>
                         <td>{{ ucwords($centre->print_pref) }}</td>
                         <td>
-                            <a href="{{ route('admin.centres.edit', ['id' => $centre->id]) }}" style="padding:5px;" class="link-button">
+                            <a href="{{ route('admin.centres.edit', ['centre' => $centre->id]) }}" style="padding:5px;" class="link-button">
                               Edit
                             </a>
                         </td>

--- a/routes/service.php
+++ b/routes/service.php
@@ -143,10 +143,10 @@ Route::group(['middleware' => 'auth:admin'], function () {
         'as' => 'admin.centres.store',
         'uses' => 'Admin\CentresController@store',
     ]);
-    Route::put('centres/{id}/update', [
+    Route::put('centres/{centre}/update', [
         'as' => 'admin.centres.update',
         'uses' => 'Admin\CentresController@update',
-    ])->where('id', '^[0-9]+$');
+    ])->where('centre', '^[0-9]+$');
     Route::get('centres/{id}/edit', [
         'as' => 'admin.centres.edit',
         'uses' => 'Admin\CentresController@edit',

--- a/routes/service.php
+++ b/routes/service.php
@@ -135,10 +135,10 @@ Route::group(['middleware' => 'auth:admin'], function () {
         'as' => 'admin.centres.create',
         'uses' => 'Admin\CentresController@create',
     ]);
-    Route::get('centres/{id}/neighbours', [
+    Route::get('centres/{centre}/neighbours', [
         'as' => 'admin.centre_neighbours.index',
         'uses' => 'Admin\CentresController@getNeighboursAsJson'
-    ])->where('id', '^[0-9]+$');
+    ])->where('centre', '^[0-9]+$');
     Route::post('centres', [
         'as' => 'admin.centres.store',
         'uses' => 'Admin\CentresController@store',
@@ -147,10 +147,10 @@ Route::group(['middleware' => 'auth:admin'], function () {
         'as' => 'admin.centres.update',
         'uses' => 'Admin\CentresController@update',
     ])->where('centre', '^[0-9]+$');
-    Route::get('centres/{id}/edit', [
+    Route::get('centres/{centre}/edit', [
         'as' => 'admin.centres.edit',
         'uses' => 'Admin\CentresController@edit',
-    ])->where('id', '^[0-9]+$');
+    ])->where('centre', '^[0-9]+$');
 
     // Sponsor Management
     Route::get('sponsors', [

--- a/tests/Unit/Controllers/Service/Admin/CentreControllerTest.php
+++ b/tests/Unit/Controllers/Service/Admin/CentreControllerTest.php
@@ -14,17 +14,13 @@ class CentreControllerTest extends StoreTestCase
 {
     use RefreshDatabase;
 
-    /** @var AdminUser $adminUser */
-    private $adminUser;
+    private AdminUser $adminUser;
 
-    /** @var Sponsor $sponsor */
-    private $sponsor;
+    private Sponsor $sponsor;
 
-    /** @var array $data */
-    private $data;
+    private array $data;
 
-    /** @var Generator $faker */
-    private $faker;
+    private Generator $faker;
 
     public function setUp(): void
     {
@@ -34,9 +30,10 @@ class CentreControllerTest extends StoreTestCase
         $this->sponsor = factory(Sponsor::class)->create();
         $this->data = [
             'name' => $this->faker->city,
-            'sponsor' => $this->sponsor->id,
-            'rvid_prefix' => strtoupper($this->faker->lexify(str_repeat('?', rand(1, 5)))),
-            'print_pref' => array_random(config('arc.print_preferences'))
+            'sponsor_id' => $this->sponsor->id,
+            'prefix' => strtoupper($this->faker->lexify(str_repeat('?', random_int(1, 5)))),
+            'print_pref' => array_random(config('arc.print_preferences')),
+            'can_collect' => random_int(0, 1)
         ];
     }
 
@@ -53,18 +50,18 @@ class CentreControllerTest extends StoreTestCase
             ->seePageIs(route('admin.centres.index'))
             ->see($this->data["name"])
             ->see($this->sponsor->name)
-            ->see($this->data["rvid_prefix"])
+            ->see($this->data["prefix"])
             ->see($this->data["print_pref"])
         ;
         // find the centre by prefix
-        $c = Centre::where('prefix', $this->data['rvid_prefix'])->first();
+        $c = Centre::where('prefix', $this->data['prefix'])->first();
         $this->assertNotNull($c);
     }
 
 
     public function testICanSeeAnEditButtonOnTheListOfCentres(): void
     {
-        $centre = factory(Centre::class)->create([]);
+        $centre = factory(Centre::class)->create();
         $this->actingAs($this->adminUser, 'admin')
             ->get(route('admin.centres.index'))
             ->assertResponseOk()
@@ -74,21 +71,21 @@ class CentreControllerTest extends StoreTestCase
         ;
     }
 
-
     public function testICanUpdateACentreName(): void
     {
-        $centre = factory(Centre::class)->create([]);
-        $data = [
-          'id' => $centre->id,
-          'name' => 'New Centre Name'
-        ];
+        $centre = factory(Centre::class)->create();
         $this->seeInDatabase('centres', [
             'id' => $centre->id,
             'name' => $centre->name
         ]);
+
+        $data = [
+            'id' => $centre->id,
+            'name' => 'New Centre Name',
+        ];
         $this->actingAs($this->adminUser, 'admin')
           ->put(
-              route('admin.centres.update', ['id' => $centre->id]),
+              route('admin.centres.update', ['centre' => $centre->id]),
               $data
           );
         $this->seeInDatabase('centres', [

--- a/tests/Unit/Controllers/Service/Admin/CentreControllerTest.php
+++ b/tests/Unit/Controllers/Service/Admin/CentreControllerTest.php
@@ -71,7 +71,7 @@ class CentreControllerTest extends StoreTestCase
         ;
     }
 
-    public function testICanUpdateACentreName(): void
+    public function testICanUpdateACentre(): void
     {
         $centre = factory(Centre::class)->create();
         $this->seeInDatabase('centres', [
@@ -79,10 +79,7 @@ class CentreControllerTest extends StoreTestCase
             'name' => $centre->name
         ]);
 
-        $data = [
-            'id' => $centre->id,
-            'name' => 'New Centre Name',
-        ];
+        $data = array_merge($centre->getAttributes(), ['name' => 'New Centre Name']);
         $this->actingAs($this->adminUser, 'admin')
           ->put(
               route('admin.centres.update', ['centre' => $centre->id]),

--- a/tests/Unit/FormRequests/AdminNewCentreRequestTest.php
+++ b/tests/Unit/FormRequests/AdminNewCentreRequestTest.php
@@ -41,89 +41,132 @@ class AdminNewCentreRequestTest extends StoreTestCase
     {
         yield 'Valid request' => [true, [
             'name' => 'Test Centre',
-            'sponsor' => 1,
-            'rvid_prefix' => 'TSTCT',
+            'sponsor_id' => 1,
+            'prefix' => 'TSTCT',
             'print_pref' => 'individual',
+            'can_collect' => false,
         ]];
 
         yield 'Missing name' => [false, [
-            'sponsor' => 1,
-            'rvid_prefix' => 'TSTCT',
+            'sponsor_id' => 1,
+            'prefix' => 'TSTCT',
             'print_pref' => 'individual',
+            'can_collect' => false,
         ]];
 
         yield 'Name is not a string' => [false, [
             'name' => 1,
-            'sponsor' => 1,
-            'rvid_prefix' => 'TSTCT',
+            'sponsor_id' => 1,
+            'prefix' => 'TSTCT',
             'print_pref' => 'individual',
+            'can_collect' => false,
         ]];
 
         yield 'Missing sponsor' => [false, [
             'name' => 'Test Centre',
-            'rvid_prefix' => 'TSTCT',
+            'prefix' => 'TSTCT',
             'print_pref' => 'individual',
+            'can_collect' => false,
         ]];
 
         yield 'Sponsor is not an integer' => [false, [
             'name' => 'Test Centre',
-            'sponsor' => 'not an integer',
-            'rvid_prefix' => 'TSTCT',
+            'sponsor_id' => 'not an integer',
+            'prefix' => 'TSTCT',
             'print_pref' => 'individual',
+            'can_collect' => false,
         ]];
 
         yield 'Invalid sponsor' => [false, [
             'name' => 'Test Centre',
-            'sponsor' => 999,
-            'rvid_prefix' => 'TSTCT',
+            'sponsor_id' => 999,
+            'prefix' => 'TSTCT',
             'print_pref' => 'individual',
+            'can_collect' => false,
         ]];
 
         yield 'Missing RVID prefix' => [false, [
             'name' => 'Test Centre',
-            'sponsor' => 1,
+            'sponsor_id' => 1,
             'print_pref' => 'individual',
+            'can_collect' => false,
         ]];
 
         yield 'RVID is not a string' => [false, [
             'name' => 'Test Centre',
-            'sponsor' => 1,
-            'rvid_prefix' => 1,
+            'sponsor_id' => 1,
+            'prefix' => 1,
             'print_pref' => 'individual',
         ]];
 
         yield 'RVID is less than one character' => [false, [
             'name' => 'Test Centre',
-            'sponsor' => 1,
-            'rvid_prefix' => '',
+            'sponsor_id' => 1,
+            'prefix' => '',
             'print_pref' => 'individual',
+            'can_collect' => false,
         ]];
 
         yield 'RVID is more than five characters' => [false, [
             'name' => 'Test Centre',
-            'sponsor' => 1,
-            'rvid_prefix' => 'ABCDEF',
+            'sponsor_id' => 1,
+            'prefix' => 'ABCDEF',
             'print_pref' => 'individual',
+            'can_collect' => false,
         ]];
 
         yield 'RVID already exists' => [false, [
             'name' => 'Test Centre',
-            'sponsor' => 1,
-            'rvid_prefix' => 'EXISTS',
+            'sponsor_id' => 1,
+            'prefix' => 'EXISTS',
             'print_pref' => 'not even slightly a print pref',
+            'can_collect' => false,
         ]];
 
         yield 'Missing print preference' => [false, [
             'name' => 'Test Centre',
-            'sponsor' => 1,
-            'rvid_prefix' => 'ABCDEF',
+            'sponsor_id' => 1,
+            'prefix' => 'ABCDEF',
+            'can_collect' => false,
         ]];
 
         yield 'Invalid print preference' => [false, [
             'name' => 'Test Centre',
-            'sponsor' => 1,
-            'rvid_prefix' => 'ABCDEF',
+            'sponsor_id' => 1,
+            'prefix' => 'ABCDEF',
             'print_pref' => 'not even slightly a print pref',
+            'can_collect' => false,
+        ]];
+
+        yield 'can_collect can be true' => [true, [
+            'name' => 'Test Centre',
+            'sponsor_id' => 1,
+            'prefix' => 'TSTCT',
+            'print_pref' => 'individual',
+            'can_collect' => true,
+        ]];
+
+        yield 'can_collect might be absent' => [true, [
+            'name' => 'Test Centre',
+            'sponsor_id' => 1,
+            'prefix' => 'TSTCT',
+            'print_pref' => 'individual',
+        ]];
+
+        yield 'can_collect might be null' => [true, [
+            'name' => 'Test Centre',
+            'sponsor_id' => 1,
+            'prefix' => 'TSTCT',
+            'print_pref' => 'individual',
+            'can_collect' => null,
+        ]];
+
+        yield 'can_collect must be boolean' => [false, [
+            'name' => 'Test Centre',
+            'sponsor_id' => 1,
+            'prefix' => 'TSTCT',
+            'print_pref' => 'individual',
+            'can_collect' => 'true',
         ]];
     }
 }

--- a/tests/Unit/FormRequests/AdminNewCentreRequestTest.php
+++ b/tests/Unit/FormRequests/AdminNewCentreRequestTest.php
@@ -22,7 +22,7 @@ class AdminNewCentreRequestTest extends StoreTestCase
         parent::setUp();
 
         $this->rules = (new AdminNewCentreRequest())->rules();
-        factory(Centre::class)->create(['prefix' => 'EXISTS']);
+        factory(Centre::class)->create(['name' => 'EXIST', 'prefix' => 'EXIST']);
         factory(Sponsor::class)->create();
     }
 
@@ -56,6 +56,14 @@ class AdminNewCentreRequestTest extends StoreTestCase
 
         yield 'Name is not a string' => [false, [
             'name' => 1,
+            'sponsor_id' => 1,
+            'prefix' => 'TSTCT',
+            'print_pref' => 'individual',
+            'can_collect' => false,
+        ]];
+
+        yield 'Name already exists' => [false, [
+            'name' => 'EXIST',
             'sponsor_id' => 1,
             'prefix' => 'TSTCT',
             'print_pref' => 'individual',
@@ -118,8 +126,8 @@ class AdminNewCentreRequestTest extends StoreTestCase
         yield 'RVID already exists' => [false, [
             'name' => 'Test Centre',
             'sponsor_id' => 1,
-            'prefix' => 'EXISTS',
-            'print_pref' => 'not even slightly a print pref',
+            'prefix' => 'EXIST',
+            'print_pref' => 'individual',
             'can_collect' => false,
         ]];
 

--- a/tests/Unit/FormRequests/AdminUpdateCentreRequestTest.php
+++ b/tests/Unit/FormRequests/AdminUpdateCentreRequestTest.php
@@ -1,0 +1,333 @@
+<?php
+
+namespace Tests\Unit\FormRequests;
+
+use App\Centre;
+use App\Http\Requests\AdminUpdateCentreRequest;
+use App\Sponsor;
+use Generator;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Validator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\StoreTestCase;
+use Closure;
+
+class AdminUpdateCentreRequestTest extends StoreTestCase
+{
+    use RefreshDatabase;
+
+    private array $rules;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->rules = (new AdminUpdateCentreRequest())->rules();
+        factory(Centre::class)->create(['name' => 'EXIST', 'prefix' => 'EXIST']);
+        factory(Sponsor::class)->create();
+    }
+
+    private function validate(array $mockedRequestData): bool
+    {
+        return Validator::make($mockedRequestData, $this->rules)->passes();
+    }
+
+    private function validateAsUpdate(Centre $centre, array $data): bool
+    {
+        $request = new AdminUpdateCentreRequest();
+        $request->setRouteResolver(function () use ($centre) {
+            return new class ($centre) {
+                public function __construct(private readonly Centre $centre)
+                {
+                }
+
+                public function parameter(string $name): mixed
+                {
+                    return $name === 'centre' ? $this->centre : null;
+                }
+            };
+        });
+
+        return Validator::make($data, $request->rules())->passes();
+    }
+
+
+    #[DataProvider('validationCases')]
+    public function testItValidatesCentreRequests(
+        bool $shouldPass,
+        array $mockedRequestData,
+        ?Closure $centreFn = null
+    ): void {
+        if ($centreFn) {
+            $centre = $centreFn();
+            $this->assertEquals($shouldPass, $this->validateAsUpdate($centre, $mockedRequestData));
+        } else {
+            $this->assertEquals($shouldPass, $this->validate($mockedRequestData));
+        }
+    }
+
+    public static function validationCases(): Generator
+    {
+        yield 'Valid request' => [
+            true,
+            [
+                'name' => 'Test Centre',
+                'sponsor_id' => 1,
+                'prefix' => 'TSTCT',
+                'print_pref' => 'individual',
+                'can_collect' => false,
+            ],
+        ];
+
+        yield 'Missing name' => [
+            false,
+            [
+                'sponsor_id' => 1,
+                'prefix' => 'TSTCT',
+                'print_pref' => 'individual',
+                'can_collect' => false,
+            ],
+        ];
+
+        yield 'Name is not a string' => [
+            false,
+            [
+                'name' => 1,
+                'sponsor_id' => 1,
+                'prefix' => 'TSTCT',
+                'print_pref' => 'individual',
+                'can_collect' => false,
+            ],
+        ];
+
+        yield 'Name already exists' => [
+            false,
+            [
+                'name' => 'EXIST',
+                'sponsor_id' => 1,
+                'prefix' => 'TSTCT',
+                'print_pref' => 'individual',
+                'can_collect' => false,
+            ],
+        ];
+
+        yield 'Missing sponsor' => [
+            false,
+            [
+                'name' => 'Test Centre',
+                'prefix' => 'TSTCT',
+                'print_pref' => 'individual',
+                'can_collect' => false,
+            ],
+        ];
+
+        yield 'Sponsor is not an integer' => [
+            false,
+            [
+                'name' => 'Test Centre',
+                'sponsor_id' => 'not an integer',
+                'prefix' => 'TSTCT',
+                'print_pref' => 'individual',
+                'can_collect' => false,
+            ],
+        ];
+
+        yield 'Invalid sponsor' => [
+            false,
+            [
+                'name' => 'Test Centre',
+                'sponsor_id' => 999,
+                'prefix' => 'TSTCT',
+                'print_pref' => 'individual',
+                'can_collect' => false,
+            ],
+        ];
+
+        yield 'Missing RVID prefix' => [
+            false,
+            [
+                'name' => 'Test Centre',
+                'sponsor_id' => 1,
+                'print_pref' => 'individual',
+                'can_collect' => false,
+            ],
+        ];
+
+        yield 'RVID is not a string' => [
+            false,
+            [
+                'name' => 'Test Centre',
+                'sponsor_id' => 1,
+                'prefix' => 1,
+                'print_pref' => 'individual',
+            ],
+        ];
+
+        yield 'RVID is less than one character' => [
+            false,
+            [
+                'name' => 'Test Centre',
+                'sponsor_id' => 1,
+                'prefix' => '',
+                'print_pref' => 'individual',
+                'can_collect' => false,
+            ],
+        ];
+
+        yield 'RVID is more than five characters' => [
+            false,
+            [
+                'name' => 'Test Centre',
+                'sponsor_id' => 1,
+                'prefix' => 'ABCDEF',
+                'print_pref' => 'individual',
+                'can_collect' => false,
+            ],
+        ];
+
+        yield 'RVID already exists' => [
+            false,
+            [
+                'name' => 'Test Centre',
+                'sponsor_id' => 1,
+                'prefix' => 'EXISTS',
+                'print_pref' => 'individual',
+                'can_collect' => false,
+            ],
+        ];
+
+        yield 'Missing print preference' => [
+            false,
+            [
+                'name' => 'Test Centre',
+                'sponsor_id' => 1,
+                'prefix' => 'ABCDEF',
+                'can_collect' => false,
+            ],
+        ];
+
+        yield 'Invalid print preference' => [
+            false,
+            [
+                'name' => 'Test Centre',
+                'sponsor_id' => 1,
+                'prefix' => 'ABCDEF',
+                'print_pref' => 'not even slightly a print pref',
+                'can_collect' => false,
+            ],
+        ];
+
+        yield 'can_collect can be true' => [
+            true,
+            [
+                'name' => 'Test Centre',
+                'sponsor_id' => 1,
+                'prefix' => 'TSTCT',
+                'print_pref' => 'individual',
+                'can_collect' => true,
+            ],
+        ];
+
+        yield 'can_collect might be absent' => [
+            true,
+            [
+                'name' => 'Test Centre',
+                'sponsor_id' => 1,
+                'prefix' => 'TSTCT',
+                'print_pref' => 'individual',
+            ],
+        ];
+
+        yield 'can_collect might be null' => [
+            true,
+            [
+                'name' => 'Test Centre',
+                'sponsor_id' => 1,
+                'prefix' => 'TSTCT',
+                'print_pref' => 'individual',
+                'can_collect' => null,
+            ],
+        ];
+
+        yield 'can_collect must be boolean' => [
+            false,
+            [
+                'name' => 'Test Centre',
+                'sponsor_id' => 1,
+                'prefix' => 'TSTCT',
+                'print_pref' => 'individual',
+                'can_collect' => 'true',
+            ],
+        ];
+
+        yield 'Centre can keep its own name' => [
+            true,
+            [
+                'name' => 'EXIST',
+                'sponsor_id' => 1,
+                'prefix' => 'TSTCT',
+                'print_pref' => 'individual',
+                'can_collect' => false,
+            ],
+            function () {
+                return Centre::where('name', 'EXIST')->first();
+            },
+        ];
+
+        yield 'Centre can keep its own prefix' => [
+            true,
+            [
+                'name' => 'Test Centre',
+                'sponsor_id' => 1,
+                'prefix' => 'EXIST',
+                'print_pref' => 'individual',
+                'can_collect' => false,
+            ],
+            function () {
+                return Centre::where('prefix', 'EXIST')->first();
+            },
+        ];
+
+        yield 'Centre can keep both its own name and prefix' => [
+            true,
+            [
+                'name' => 'EXIST',
+                'sponsor_id' => 1,
+                'prefix' => 'EXIST',
+                'print_pref' => 'individual',
+                'can_collect' => false,
+            ],
+            function () {
+                return Centre::where('name', 'EXIST')->first();
+            },
+        ];
+
+        yield 'Another centres name is still rejected' => [
+            false,
+            [
+                'name' => 'EXIST',
+                'sponsor_id' => 1,
+                'prefix' => 'OTHER',
+                'print_pref' => 'individual',
+                'can_collect' => false,
+            ],
+            function () {
+                return factory(Centre::class)->create(['name' => 'Other Centre', 'prefix' => 'OTHER']);
+            },
+        ];
+
+        yield 'Another centres prefix is still rejected' => [
+            false,
+            [
+                'name' => 'Other Centre',
+                'sponsor_id' => 1,
+                'prefix' => 'EXIST',
+                'print_pref' => 'individual',
+                'can_collect' => false,
+            ],
+            function () {
+                return factory(Centre::class)->create(['name' => 'Other Centre', 'prefix' => 'OTHER']);
+            },
+        ];
+    }
+}

--- a/tests/Unit/Routes/ServiceRoutesTest.php
+++ b/tests/Unit/Routes/ServiceRoutesTest.php
@@ -33,7 +33,7 @@ class ServiceRoutesTest extends StoreTestCase
             'admin.deliveries.index' => [],
             'admin.centres.index' => [],
             'admin.centres.create' => [],
-            'admin.centre_neighbours.index' => ['id' => 1],
+            'admin.centre_neighbours.index' => ['centre' => 1],
             'admin.sponsors.index' => [],
             'admin.sponsors.create' => [],
             'admin.markets.index' => [],
@@ -113,6 +113,7 @@ class ServiceRoutesTest extends StoreTestCase
                     ->makeRequest($method, route($route, $params))
                     ->followRedirects()
                     ->response;
+
                 // Expecting 403 or return to "/login"
                 $this->assertTrue(
                     $response->isForbidden()


### PR DESCRIPTION
https://trello.com/c/wXGqdOd5/2254-amend-centres-so-they-can-be-set-to-collect-vouchers-eee-vvv

This adds a checkbox to the create and edit pages that will set the flag on the centre model

on the way:
- modernised the centre creation page
- used that as a base to update the utterly shonky centre edit page
- updated the validation rules for both
- simplified the store and update methods
- fixed some routes
- nudged some css to do with vertically positioning label text against the checkboxes
- added some tests to cover the new cases
- fixed some tests to do with prefixes that passing for the wrong reasons (the "EXISTS" prefix was too long, but that passed _because_ it was triggering a string length rule, not for whatever reason the test needed) 