### PR TITLE
1.20/2268 centres can have integrated markets

### DIFF
--- a/app/Centre.php
+++ b/app/Centre.php
@@ -2,7 +2,9 @@
 
 namespace App;
 
+use App\Observers\CentreObserver;
 use Eloquent;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\belongsToMany;
@@ -20,6 +22,8 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * @property Centre[] $neighbours
  * @property Family[] $families
  */
+
+#[ObservedBy(CentreObserver::class)]
 class Centre extends Model
 {
     /**

--- a/app/Centre.php
+++ b/app/Centre.php
@@ -28,7 +28,11 @@ class Centre extends Model
      * @var array
      */
     protected $fillable = [
-        'name', 'prefix', 'print_pref', 'sponsor_id', 'can_collect'
+        'name',
+        'prefix',
+        'print_pref',
+        'sponsor_id',
+        'can_collect',
     ];
 
     /**
@@ -45,7 +49,7 @@ class Centre extends Model
      * @var array
      */
     protected $casts = [
-        'can_collect' => 'boolean'
+        'can_collect' => 'boolean',
     ];
 
     public function nextCentreSequence(): int
@@ -62,6 +66,15 @@ class Centre extends Model
         }
 
         return $sequence;
+    }
+
+    /**
+     * All internal markets for this centre.
+     * Use the open() scope to restrict to those with at least one trader.
+     */
+    public function markets(): HasMany
+    {
+        return $this->hasMany(Market::class);
     }
 
     /**

--- a/app/Market.php
+++ b/app/Market.php
@@ -3,6 +3,7 @@
 namespace App;
 
 use DateTimeInterface;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -28,6 +29,7 @@ class Market extends Model
         'name',
         'location',
         'sponsor_id',
+        'centre_id',
         'payment_message',
     ];
 
@@ -51,43 +53,59 @@ class Market extends Model
     ];
 
     /**
-     * Get the sponsor this market belongs to.
-     *
-     * @return BelongsTo
+     * If this is an "internal market" it will have a centre
      */
-    public function sponsor()
+    public function centre(): BelongsTo
+    {
+        return $this->belongsTo(Centre::class);
+    }
+
+
+    /**
+     * Get the sponsor this market belongs to.
+     */
+    public function sponsor(): BelongsTo
     {
         return $this->belongsTo(Sponsor::class);
     }
 
     /**
      * Get the traders this market has.
-     *
-     * @return HasMany
      */
-    public function traders()
+    public function traders(): HasMany
     {
         return $this->hasMany(Trader::class);
     }
 
     /**
-     * Get the sponsor shortcode.
-     *
-     * @return string
+     * Scope to markets that have at least one trader — i.e. are open for business.
      */
-    public function getSponsorShortcodeAttribute()
+    public function scopeTrading(Builder $query): Builder
     {
-        return $this->sponsor->shortcode;
+        return $query->has('traders');
+    }
+
+    /**
+     * Get the sponsor shortcode.
+     */
+    public function getSponsorShortcodeAttribute(): ?string
+    {
+        return $this->sponsor?->shortcode;
     }
 
     /**
      * Prepare a date for array / JSON serialization.
-     *
-     * @param  \DateTimeInterface  $date
-     * @return string
      */
-    protected function serializeDate(DateTimeInterface $date)
+    protected function serializeDate(DateTimeInterface $date): string
     {
         return $date->format('Y-m-d H:i:s');
+    }
+
+    /**
+     * Is it internal?
+     */
+    public function isInternal(): bool
+    {
+        return $this->centre_id !== null;
     }
 }

--- a/app/Observers/CentreObserver.php
+++ b/app/Observers/CentreObserver.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Observers;
+
+use App\Centre;
+use App\Services\CentreCollectionMarketService;
+
+readonly class CentreObserver
+{
+    private CentreCollectionMarketService $marketService;
+
+    public function __construct(
+        CentreCollectionMarketService $marketService
+    ) {
+        $this->marketService = $marketService;
+    }
+
+    public function created(Centre $centre): void
+    {
+        if ($centre->can_collect) {
+            $this->marketService->ensureMarket($centre);
+        }
+    }
+
+    public function updating(Centre $centre): void
+    {
+        if (!$centre->isDirty('can_collect')) {
+            return;
+        }
+
+        if ($centre->can_collect) {
+            $this->marketService->ensureMarket($centre);
+        }
+    }
+}

--- a/app/Observers/CentreObserver.php
+++ b/app/Observers/CentreObserver.php
@@ -18,7 +18,7 @@ readonly class CentreObserver
     public function created(Centre $centre): void
     {
         if ($centre->can_collect) {
-            $this->marketService->ensureMarket($centre);
+            $this->marketService->ensureTradingMarket($centre);
         }
     }
 
@@ -29,7 +29,7 @@ readonly class CentreObserver
         }
 
         if ($centre->can_collect) {
-            $this->marketService->ensureMarket($centre);
+            $this->marketService->ensureTradingMarket($centre);
         }
     }
 }

--- a/app/Services/CentreCollectionMarketService.php
+++ b/app/Services/CentreCollectionMarketService.php
@@ -8,34 +8,29 @@ use App\Trader;
 
 class CentreCollectionMarketService
 {
-    public function ensureMarket(Centre $centre): Market
+    public function ensureTradingMarket(Centre $centre): void
     {
-        // withTrashed guards against the edge case where someone
-        // manually soft-deleted the market outside normal flows.
-        $market = Market::withTrashed()
-            ->where('centre_id', $centre->id)
-            ->first();
-
-        if ($market) {
-            // Restore if soft-deleted
-            if ($market->trashed()) {
-                $market->restore();
-            }
-        } else {
-            $market = Market::create([
-                'name' => $centre->name . ' Collection',
-                'location' => $centre->name,
-                'centre_id' => $centre->id,
-                'sponsor_id' => $centre->sponsor->id,
-                'payment_message' => '',
-            ]);
-
-            Trader::create([
-                'name' => $centre->name . ' Collection Trader',
-                'market_id' => $market->id,
-            ]);
+        // is there already one from a prior can_collect toggle?
+        if (Market::where('centre_id', $centre->id)->trading()->exists()) {
+            return;
         }
 
-        return $market;
+        // there are no active markets with traders that are assigned to this centre,
+        // better make one ...
+        $market = Market::create([
+            'name' => $centre->name . ' (Internal)',
+            'location' => $centre->name,
+            'centre_id' => $centre->id,
+            // assign it the centre's sponsor/area
+            'sponsor_id' => $centre->sponsor->id,
+            // don't need one of these, the payment recommendation will be automated
+            'payment_message' => '',
+        ]);
+
+        // ... and it's trader
+        Trader::create([
+            'name' => $centre->name . ' (Internal)',
+            'market_id' => $market->id,
+        ]);
     }
 }

--- a/app/Services/CentreCollectionMarketService.php
+++ b/app/Services/CentreCollectionMarketService.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Services;
+
+use App\Centre;
+use App\Market;
+use App\Trader;
+
+class CentreCollectionMarketService
+{
+    public function ensureMarket(Centre $centre): Market
+    {
+        // withTrashed guards against the edge case where someone
+        // manually soft-deleted the market outside normal flows.
+        $market = Market::withTrashed()
+            ->where('centre_id', $centre->id)
+            ->first();
+
+        if ($market) {
+            // Restore if soft-deleted
+            if ($market->trashed()) {
+                $market->restore();
+            }
+        } else {
+            $market = Market::create([
+                'name' => $centre->name . ' Collection',
+                'location' => $centre->name,
+                'centre_id' => $centre->id,
+                'sponsor_id' => $centre->sponsor->id,
+                'payment_message' => '',
+            ]);
+
+            Trader::create([
+                'name' => $centre->name . ' Collection Trader',
+                'market_id' => $market->id,
+            ]);
+        }
+
+        return $market;
+    }
+}

--- a/app/Services/CentreCollectionMarketService.php
+++ b/app/Services/CentreCollectionMarketService.php
@@ -27,7 +27,7 @@ class CentreCollectionMarketService
             'payment_message' => '',
         ]);
 
-        // ... and it's trader
+        // ... and its trader
         Trader::create([
             'name' => $centre->name . ' (Internal)',
             'market_id' => $market->id,

--- a/database/migrations/2026_04_10_094810_add_centre_id_to_internal_markets.php
+++ b/database/migrations/2026_04_10_094810_add_centre_id_to_internal_markets.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('markets', static function (Blueprint $table) {
+            $table->unsignedInteger('centre_id')->nullable()->after('sponsor_id');
+            $table->foreign('centre_id')->references('id')->on('centres')->nullOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::withoutForeignKeyConstraints(static function () {
+            Schema::table('markets', static function (Blueprint $table) {
+                $table->dropForeign(['centre_id']);
+                $table->dropColumn('centre_id');
+            });
+        });
+    }
+};

--- a/tests/Unit/Models/CentreModelTest.php
+++ b/tests/Unit/Models/CentreModelTest.php
@@ -3,9 +3,10 @@
 namespace Tests\Unit\Models;
 
 use App\Centre;
+use App\CentreUser;
 use App\Registration;
 use App\Sponsor;
-use App\CentreUser;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Collection;
 use Tests\TestCase;
@@ -14,15 +15,14 @@ class CentreModelTest extends TestCase
 {
     use RefreshDatabase;
 
-
     public function testItHasExpectedAttributes(): void
     {
         $centre = factory(Centre::class)->make();
         $this->assertNotNull($centre->name);
         $this->assertNotNull($centre->sponsor_id);
         $this->assertContains($centre->print_pref, config('arc.print_preferences'));
+        $this->assertFalse($centre->can_collect);
     }
-
 
     public function testItHasASponsor(): void
     {
@@ -31,7 +31,6 @@ class CentreModelTest extends TestCase
         ]);
         $this->assertInstanceOf(Sponsor::class, $centre->sponsor);
     }
-
 
     public function testItCanHaveRegistrations(): void
     {
@@ -44,7 +43,6 @@ class CentreModelTest extends TestCase
         $this->assertInstanceOf(Registration::class, $registrations[0]);
     }
 
-
     public function testItCanHaveNoRegistrations(): void
     {
         $centre = factory(Centre::class)->create();
@@ -52,7 +50,6 @@ class CentreModelTest extends TestCase
         $this->assertInstanceOf(Collection::class, $registrations);
         $this->assertEquals(0, $registrations->count());
     }
-
 
     public function testItCanHaveUsers(): void
     {
@@ -72,7 +69,6 @@ class CentreModelTest extends TestCase
         $this->assertInstanceOf(Collection::class, $centreUsers);
         $this->assertInstanceOf(CentreUser::class, $centreUsers[0]);
     }
-
 
     public function testItCanHaveNeighbours(): void
     {
@@ -100,12 +96,6 @@ class CentreModelTest extends TestCase
         }
     }
 
-    public function testItCanNotCollectByDefault(): void
-    {
-        $centre = factory(Centre::class)->create();
-        $this->assertFalse($centre->can_collect);
-    }
-
     public function testItCanBeSetToCollect(): void
     {
         $centre = factory(Centre::class)->states('collecting')->create();
@@ -124,5 +114,17 @@ class CentreModelTest extends TestCase
         $centre->can_collect = false;
         $centre->save();
         $this->assertFalse(Centre::find($centre->id)->can_collect);
+    }
+
+    public function testMarketsIsAHasManyRelation(): void
+    {
+        $centre = factory(Centre::class)->create();
+        $this->assertInstanceOf(HasMany::class, $centre->markets());
+    }
+
+    public function testMarketsOnNonCollectingCentreIsEmpty(): void
+    {
+        $centre = factory(Centre::class)->create();
+        $this->assertCount(0, $centre->markets);
     }
 }

--- a/tests/Unit/Models/MarketModelTest.php
+++ b/tests/Unit/Models/MarketModelTest.php
@@ -2,10 +2,12 @@
 
 namespace Tests\Unit\Models;
 
+use App\Centre;
 use App\Market;
 use App\Sponsor;
-use Illuminate\Database\Eloquent\Relations\HasMany;
+use App\Trader;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -13,8 +15,9 @@ class MarketModelTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected $market;
-    protected $sponsor;
+    protected Market $market;
+    protected Sponsor $sponsor;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -25,8 +28,6 @@ class MarketModelTest extends TestCase
     public function testMarketIsCreatedWithExpectedAttributes(): void
     {
         $m = $this->market;
-        // Keeping it simple to make writing test suite less onerous.
-        // The default error returned by asserts will be enough.
         $this->assertInstanceOf(Market::class, $m);
         $this->assertNotNull($m->name);
         $this->assertNotNull($m->location);
@@ -38,7 +39,6 @@ class MarketModelTest extends TestCase
 
     public function testMarketBelongsToSponsor(): void
     {
-        $this->assertInstanceOf(BelongsTo::class, $this->market->sponsor());
         $this->assertInstanceOf(Sponsor::class, $this->market->sponsor);
     }
 
@@ -49,9 +49,7 @@ class MarketModelTest extends TestCase
 
     public function testGetSponsorShortcodeAttribute(): void
     {
-        $shortcode_market = $this->market->sponsor_shortcode;
-        $shortcode_sponsor = $this->sponsor->shortcode;
-        $this->assertEquals($shortcode_sponsor, $shortcode_market);
+        $this->assertEquals($this->sponsor->shortcode, $this->market->sponsor_shortcode);
     }
 
     public function testSoftDeleteMarket(): void
@@ -59,5 +57,96 @@ class MarketModelTest extends TestCase
         $this->market->delete();
         $this->assertCount(1, Market::withTrashed()->get());
         $this->assertCount(0, Market::all());
+    }
+
+    public function testSponsorMarketIsNotInternal(): void
+    {
+        $this->assertFalse($this->market->isInternal());
+    }
+
+    public function testInternalMarketIsInternal(): void
+    {
+        $centre = factory(Centre::class)->create();
+        $market = factory(Market::class)->create([
+            'centre_id' => $centre->id,
+            'sponsor_id' => null,
+        ]);
+
+        $this->assertTrue($market->isInternal());
+    }
+
+    public function testInternalMarketBelongsToCentre(): void
+    {
+        $centre = factory(Centre::class)->create();
+        $market = factory(Market::class)->create([
+            'centre_id' => $centre->id,
+            'sponsor_id' => null,
+        ]);
+
+        $this->assertInstanceOf(BelongsTo::class, $market->centre());
+        $this->assertInstanceOf(Centre::class, $market->centre);
+        $this->assertEquals($centre->id, $market->centre->id);
+    }
+
+    public function testSponsorMarketHasNullCentre(): void
+    {
+        $this->assertNull($this->market->centre);
+    }
+
+    public function testInternalMarketCanHaveMultipleTraders(): void
+    {
+        $centre = factory(Centre::class)->create();
+        $market = factory(Market::class)->create([
+            'centre_id' => $centre->id,
+        ]);
+
+        factory(Trader::class, 2)->create(['market_id' => $market->id]);
+
+        $this->assertCount(2, $market->traders);
+    }
+
+    public function testInternalMarketWithNoTradersHasEmptyTradersCollection(): void
+    {
+        $centre = factory(Centre::class)->create();
+        $market = factory(Market::class)->create([
+            'centre_id' => $centre->id,
+        ]);
+
+        $this->assertCount(0, $market->traders);
+    }
+
+    public function testTradingScopeReturnsMarketsWithTraders(): void
+    {
+        $centre = factory(Centre::class)->create();
+        $market = factory(Market::class)->create([
+            'centre_id' => $centre->id,
+        ]);
+        factory(Trader::class)->create(['market_id' => $market->id]);
+
+        $this->assertCount(1, Market::trading()->where('centre_id', $centre->id)->get());
+    }
+
+    public function testTradingScopeExcludesMarketsWithNoTraders(): void
+    {
+        $centre = factory(Centre::class)->create();
+        factory(Market::class)->create([
+            'centre_id' => $centre->id,
+        ]);
+
+        $this->assertCount(0, Market::trading()->where('centre_id', $centre->id)->get());
+    }
+
+    public function testSoftDeletedInternalMarketIsRestorable(): void
+    {
+        $centre = factory(Centre::class)->create();
+        $market = factory(Market::class)->create([
+            'centre_id' => $centre->id,
+        ]);
+
+        $market->delete();
+        $this->assertNull(Market::find($market->id));
+
+        $market->restore();
+        $this->assertNotNull(Market::find($market->id));
     }
 }

--- a/tests/Unit/Observers/CentreObserverTest.php
+++ b/tests/Unit/Observers/CentreObserverTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Tests\Unit\Observers;
+
+use App\Centre;
+use App\Observers\CentreObserver;
+use App\Services\CentreCollectionMarketService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
+use Tests\TestCase;
+
+class CentreObserverTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected CentreCollectionMarketService $marketService;
+    protected CentreObserver $observer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->marketService = Mockery::mock(CentreCollectionMarketService::class);
+        $this->observer = new CentreObserver($this->marketService);
+    }
+
+    public function testCreatedCallsEnsureTradingMarketWhenCentreCanCollect(): void
+    {
+        $centre = factory(Centre::class)->make(['can_collect' => true]);
+
+        $this->marketService
+            ->shouldReceive('ensureTradingMarket')
+            ->once()
+            ->with($centre);
+
+        $this->observer->created($centre);
+    }
+
+    public function testCreatedDoesNotCallEnsureTradingMarketWhenCentreCannotCollect(): void
+    {
+        $centre = factory(Centre::class)->make(['can_collect' => false]);
+
+        $this->marketService
+            ->shouldReceive('ensureTradingMarket')
+            ->never();
+
+        $this->observer->created($centre);
+    }
+
+    public function testUpdatingCallsEnsureTradingMarketWhenCanCollectFlipsToTrue(): void
+    {
+        $centre = factory(Centre::class)->create(['can_collect' => false]);
+        $centre->can_collect = true;
+
+        $this->marketService
+            ->shouldReceive('ensureTradingMarket')
+            ->once()
+            ->with($centre);
+
+        $this->observer->updating($centre);
+    }
+
+    public function testUpdatingDoesNotCallEnsureTradingMarketWhenCanCollectFlipsToFalse(): void
+    {
+        $centre = factory(Centre::class)->create(['can_collect' => true]);
+        $centre->can_collect = false;
+
+        $this->marketService
+            ->shouldReceive('ensureTradingMarket')
+            ->never();
+
+        $this->observer->updating($centre);
+    }
+
+    public function testUpdatingDoesNotCallEnsureTradingMarketWhenCanCollectIsUnchanged(): void
+    {
+        $centre = factory(Centre::class)->create(['can_collect' => true]);
+        $centre->name = 'A different name';
+
+        $this->marketService
+            ->shouldReceive('ensureTradingMarket')
+            ->never();
+
+        $this->observer->updating($centre);
+    }
+}

--- a/tests/Unit/Services/CentreCollectionMarketServiceTest.php
+++ b/tests/Unit/Services/CentreCollectionMarketServiceTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Centre;
+use App\Market;
+use App\Services\CentreCollectionMarketService;
+use App\Trader;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CentreCollectionMarketServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected CentreCollectionMarketService $service;
+    protected Centre $centre;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new CentreCollectionMarketService();
+        $this->centre = factory(Centre::class)->create(['can_collect' => false]);
+    }
+
+    public function testItCreatesAMarketWhenNoneExists(): void
+    {
+        $this->service->ensureTradingMarket($this->centre);
+
+        $this->assertCount(1, Market::where('centre_id', $this->centre->id)->get());
+    }
+
+    public function testItCreatesATraderOnTheNewMarket(): void
+    {
+        $this->service->ensureTradingMarket($this->centre);
+
+        $market = Market::where('centre_id', $this->centre->id)->first();
+        $this->assertCount(1, $market->traders);
+    }
+
+    public function testNewMarketHasExpectedAttributes(): void
+    {
+        $this->service->ensureTradingMarket($this->centre);
+
+        $market = Market::where('centre_id', $this->centre->id)->first();
+        $this->assertSame($this->centre->name . ' (Internal)', $market->name);
+        $this->assertSame($this->centre->name, $market->location);
+        $this->assertSame($this->centre->id, $market->centre_id);
+        $this->assertSame($this->centre->sponsor->id, $market->sponsor_id);
+        $this->assertSame('', $market->payment_message);
+    }
+
+    public function testNewTraderHasExpectedAttributes(): void
+    {
+        $this->service->ensureTradingMarket($this->centre);
+
+        $market = Market::where('centre_id', $this->centre->id)->first();
+        $trader = $market->traders()->first();
+        $this->assertSame($this->centre->name . ' (Internal)', $trader->name);
+        $this->assertSame($market->id, $trader->market_id);
+    }
+
+    public function testItDoesNotCreateAMarketWhenOneTradingMarketExists(): void
+    {
+        $market = factory(Market::class)->create(['centre_id' => $this->centre->id]);
+        factory(Trader::class)->create(['market_id' => $market->id]);
+
+        $this->service->ensureTradingMarket($this->centre);
+
+        $this->assertCount(1, Market::where('centre_id', $this->centre->id)->get());
+    }
+
+    public function testItDoesNotCreateAMarketWhenMultipleTradingMarketsExist(): void
+    {
+        factory(Market::class, 2)->create(['centre_id' => $this->centre->id])
+            ->each(function ($market) {
+                return factory(Trader::class)->create(['market_id' => $market->id]);
+            });
+
+        $this->service->ensureTradingMarket($this->centre);
+
+        $this->assertCount(2, Market::where('centre_id', $this->centre->id)->get());
+    }
+
+    public function testItCreatesAMarketWhenOnlyNonTradingMarketsExist(): void
+    {
+        factory(Market::class)->create(['centre_id' => $this->centre->id]);
+
+        $this->service->ensureTradingMarket($this->centre);
+
+        $this->assertCount(2, Market::where('centre_id', $this->centre->id)->get());
+    }
+
+    public function testItReturnsVoid(): void
+    {
+        $result = $this->service->ensureTradingMarket($this->centre);
+
+        $this->assertNull($result);
+    }
+}


### PR DESCRIPTION
https://trello.com/c/o6DBaEQJ/2268-centres-can-have-integrated-markets-ee-vvv
- setup a schema to make sure markets can belong to a centre if they need to
- update the models
- add an observer (new stunt: annotations on classes to register, rather than in app service provider)
- add a service to fudge creating a minimally viable market and trader if the centre needs one
- write some tests for the models, observer, service.

