### PR TITLE
1.20/2252 create a new collection confirmation control eee vvv part 3

### DIFF
--- a/app/Bundle.php
+++ b/app/Bundle.php
@@ -15,12 +15,12 @@ use RuntimeException;
 use Throwable;
 
 /**
- * @property int            $entitlement
- * @property Registration   $registration
- * @property Carer          $collectingCarer
- * @property Centre         $disbursingCentre
- * @property User           $disbursingUser
- * @property Carbon|null    $disbursed_at
+ * @property int $entitlement
+ * @property Registration $registration
+ * @property Carer $collectingCarer
+ * @property Centre $disbursingCentre
+ * @property User $disbursingUser
+ * @property Carbon|null $disbursed_at
  */
 class Bundle extends Model
 {
@@ -34,8 +34,8 @@ class Bundle extends Model
     ];
 
     protected $casts = [
-        'created_at'   => 'datetime',
-        'updated_at'   => 'datetime',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
         'disbursed_at' => 'datetime',
     ];
 
@@ -75,7 +75,7 @@ class Bundle extends Model
                 $voucher->bundle !== null && $bundle !== null => $errors['bundled'][] = $voucher,
 
                 // State machine forbids collecting (expired, void, recorded, payment_pending, paid).
-                !$voucher->transitionAllowed('collect')  => $errors['used'][] = $voucher->code,
+                !$voucher->transitionAllowed('collect') => $errors['used'][] = $voucher->code,
 
                 // All clear — reassign.
                 default => $voucher->bundle()->associate($bundle)->save(),

--- a/app/Http/Controllers/Store/BundleController.php
+++ b/app/Http/Controllers/Store/BundleController.php
@@ -20,7 +20,6 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
-use Request;
 use Throwable;
 
 class BundleController extends Controller

--- a/app/Http/Controllers/Store/BundleController.php
+++ b/app/Http/Controllers/Store/BundleController.php
@@ -19,6 +19,7 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
+use Request;
 use Throwable;
 
 class BundleController extends Controller
@@ -59,20 +60,35 @@ class BundleController extends Controller
     }
 
     /**
-     * Append a single voucher or range of vouchers to the current bundle.
+     * Append a single voucher, range of vouchers, or a quantity drawn from the pool
+     * to the current bundle.
      */
     public function addVouchersToCurrentBundle(
         StoreAppendBundleRequest $request,
         Registration $registration,
     ): RedirectResponse {
-        $voucherCodes = Voucher::generateCodeRange(
-            $request->input('start'),
-            $request->input('end'),
-        );
-
         $managerRoute = $this->managerRoute($registration);
 
-        $errors = count($voucherCodes) <= config('arc.bundle_max_voucher_append')
+        if ($request->filled('quantity')) {
+            try {
+                $voucherCodes = Voucher::claimFromPool((int) $request->input('quantity'))
+                    ->pluck('code')
+                    ->all();
+            } catch (Throwable $e) {
+                return $this->redirectAfterRequest(
+                    ['pool' => $e->getMessage()],
+                    $managerRoute,
+                    $managerRoute,
+                );
+            }
+        } else {
+            $voucherCodes = Voucher::generateCodeRange(
+                $request->input('start'),
+                $request->input('end'),
+            );
+        }
+
+        $errors = (count($voucherCodes) <= config('arc.bundle_max_voucher_append'))
             ? $registration->currentBundle()->addVouchers($voucherCodes)
             : ['append' => count($voucherCodes)];
 
@@ -289,5 +305,12 @@ class BundleController extends Controller
             Str::plural('voucher', $count),
             $name,
         );
+    }
+
+    /**
+     *
+     */
+    public function requestPayment(Request $request) {
+        //
     }
 }

--- a/app/Http/Controllers/Store/BundleController.php
+++ b/app/Http/Controllers/Store/BundleController.php
@@ -106,14 +106,12 @@ class BundleController extends Controller
     {
         $managerRoute = $this->managerRoute($registration);
         $bundle = $registration->currentBundle();
-        $errors = [];
 
-        if ($request->filled(['collected_at', 'collected_by', 'collected_on'])) {
-            $errors = $this->attemptDisbursal(
-                $bundle,
-                $request->only(['collected_at', 'collected_by', 'collected_on'])
-            );
-        }
+        $errors = $this->attemptDisbursal(
+            $bundle,
+            // Should be here, due to form request validation
+            $request->only(['collected_at', 'collected_by', 'collected_on'])
+        );
 
         return $this->redirectAfterRequest($errors, route('store.registration.index'), $managerRoute, $bundle);
     }
@@ -132,6 +130,7 @@ class BundleController extends Controller
             DB::transaction(function () use ($request, $bundle, &$errors) {
                 $errors = $this->attemptDisbursal(
                     $bundle,
+                    // Should be here, due to form request validation
                     $request->only(['collected_at', 'collected_by', 'collected_on'])
                 );
 
@@ -139,7 +138,7 @@ class BundleController extends Controller
                     throw new RuntimeException('disbursal errors');
                 }
 
-                $trader = Trader::findorFail($request->input('trader'));
+                $trader = Trader::findorFail($request->input('trader_id'));
                 $processor = new TransitionProcessor($trader, 'collect');
                 $processor->handle($bundle->vouchers);
 

--- a/app/Http/Controllers/Store/BundleController.php
+++ b/app/Http/Controllers/Store/BundleController.php
@@ -8,8 +8,8 @@ use App\Centre;
 use App\Family;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\StoreAppendBundleRequest;
-use App\Http\Requests\StoreRequestPaymentRequest;
-use App\Http\Requests\StoreUpdateBundleRequest;
+use App\Http\Requests\StoreTransitionBundleRequest;
+use App\Http\Requests\StorePickupBundleRequest;
 use App\Registration;
 use App\Services\TransitionProcessor;
 use App\Trader;
@@ -102,7 +102,7 @@ class BundleController extends Controller
     /**
      * Disburse the current bundle if collection details are present.
      */
-    public function update(StoreUpdateBundleRequest $request, Registration $registration): RedirectResponse
+    public function update(StorePickupBundleRequest $request, Registration $registration): RedirectResponse
     {
         $managerRoute = $this->managerRoute($registration);
         $bundle = $registration->currentBundle();
@@ -121,7 +121,7 @@ class BundleController extends Controller
     /**
      * Disburse the current bundle and trigger a collection transition.
      */
-    public function collectBundle(StoreRequestPaymentRequest $request, Registration $registration): RedirectResponse
+    public function collectBundle(StoreTransitionBundleRequest $request, Registration $registration): RedirectResponse
     {
         $managerRoute = $this->managerRoute($registration);
         $bundle = $registration->currentBundle();

--- a/app/Http/Controllers/Store/BundleController.php
+++ b/app/Http/Controllers/Store/BundleController.php
@@ -11,15 +11,19 @@ use App\Http\Requests\StoreAppendBundleRequest;
 use App\Http\Requests\StoreRequestPaymentRequest;
 use App\Http\Requests\StoreUpdateBundleRequest;
 use App\Registration;
+use App\Services\TransitionProcessor;
+use App\Trader;
 use App\Voucher;
 use Illuminate\Contracts\View\View;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
+use RuntimeException;
 use Throwable;
 
 class BundleController extends Controller
@@ -111,28 +115,50 @@ class BundleController extends Controller
             );
         }
 
-        $successRoute = empty($errors) ? route('store.registration.index') : $managerRoute;
-
-        return $this->redirectAfterRequest($errors, $successRoute, $managerRoute, $bundle);
+        return $this->redirectAfterRequest($errors, route('store.registration.index'), $managerRoute, $bundle);
     }
 
     /**
-     * Disburse the current bundle and trigger a payment request transition.
+     * Disburse the current bundle and trigger a collection transition.
      */
-    public function requestPayment(StoreRequestPaymentRequest $request, Registration $registration): RedirectResponse
+    public function collectBundle(StoreRequestPaymentRequest $request, Registration $registration): RedirectResponse
     {
         $managerRoute = $this->managerRoute($registration);
         $bundle = $registration->currentBundle();
+        $errors = [];
 
-        $errors = $this->attemptDisbursal($bundle, $request->only(['collected_at', 'collected_by', 'collected_on']));
+        try {
+            // As this is an important change, we need to rollback, rather than plough on.
+            DB::transaction(function () use ($request, $bundle, &$errors) {
+                $errors = $this->attemptDisbursal(
+                    $bundle,
+                    $request->only(['collected_at', 'collected_by', 'collected_on'])
+                );
 
-        if (empty($errors)) {
-            // TODO: trigger payment transition on $bundle
+                if (!empty($errors)) {
+                    throw new RuntimeException('disbursal errors');
+                }
+
+                $trader = Trader::findorFail($request->input('trader'));
+                $processor = new TransitionProcessor($trader, 'collect');
+                $processor->handle($bundle->vouchers);
+
+                if ($processor->hasFailures()) {
+                    $errors['transition'] = $processor->getFailureCodes();
+                    throw new RuntimeException('transition errors');
+                }
+            });
+        } catch (Throwable $e) {
+            Log::error(sprintf(
+                'Rollback Bad transaction for %s@%s by user %s because of: %e',
+                self::class,
+                __FUNCTION__,
+                Auth::id() ?? 'unauthenticated',
+                $e->getMessage()
+            ));
         }
 
-        $successRoute = empty($errors) ? route('store.registration.index') : $managerRoute;
-
-        return $this->redirectAfterRequest($errors, $successRoute, $managerRoute, $bundle);
+        return $this->redirectAfterRequest($errors, route('store.registration.index'), $managerRoute, $bundle);
     }
 
     /**
@@ -174,9 +200,7 @@ class BundleController extends Controller
             return ['empty' => true];
         }
 
-        return ($this->disburseBundle($bundle, $inputs))
-            ? ['transaction' => true]
-            : [];
+        return $this->disburseBundle($bundle, $inputs) ? [] : ['transaction' => true];
     }
 
     /**

--- a/app/Http/Controllers/Store/BundleController.php
+++ b/app/Http/Controllers/Store/BundleController.php
@@ -8,6 +8,7 @@ use App\Centre;
 use App\Family;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\StoreAppendBundleRequest;
+use App\Http\Requests\StoreRequestPaymentRequest;
 use App\Http\Requests\StoreUpdateBundleRequest;
 use App\Registration;
 use App\Voucher;
@@ -69,9 +70,9 @@ class BundleController extends Controller
     ): RedirectResponse {
         $managerRoute = $this->managerRoute($registration);
 
-        if ($request->filled('quantity')) {
+        if ($request->filled('voucher-quantity')) {
             try {
-                $voucherCodes = Voucher::claimFromPool((int) $request->input('quantity'))
+                $voucherCodes = Voucher::claimFromPool((int)$request->input('voucher-quantity'))
                     ->pluck('code')
                     ->all();
             } catch (Throwable $e) {
@@ -96,43 +97,41 @@ class BundleController extends Controller
     }
 
     /**
-     * Update (sync) vouchers on the current bundle, and optionally disburse it.
+     * Disburse the current bundle if collection details are present.
      */
     public function update(StoreUpdateBundleRequest $request, Registration $registration): RedirectResponse
     {
         $managerRoute = $this->managerRoute($registration);
-        $successRoute = $managerRoute;
+        $bundle = $registration->currentBundle();
         $errors = [];
 
-        /** @var Bundle $bundle */
+        if ($request->filled(['collected_at', 'collected_by', 'collected_on'])) {
+            $errors = $this->attemptDisbursal(
+                $bundle,
+                $request->only(['collected_at', 'collected_by', 'collected_on'])
+            );
+        }
+
+        $successRoute = empty($errors) ? route('store.registration.index') : $managerRoute;
+
+        return $this->redirectAfterRequest($errors, $successRoute, $managerRoute, $bundle);
+    }
+
+    /**
+     * Disburse the current bundle and trigger a payment request transition.
+     */
+    public function requestPayment(StoreRequestPaymentRequest $request, Registration $registration): RedirectResponse
+    {
+        $managerRoute = $this->managerRoute($registration);
         $bundle = $registration->currentBundle();
 
-        // --- Sync voucher codes if supplied ---
-        if ($request->exists('vouchers')) {
-            $rawCodes = array_filter($request->input('vouchers', []));
+        $errors = $this->attemptDisbursal($bundle, $request->only(['collected_at', 'collected_by', 'collected_on']));
 
-            $voucherCodes = $rawCodes !== []
-                ? Voucher::cleanCodes(array_values($rawCodes))
-                : [];
-
-            $errors = array_merge_recursive($errors, $bundle->syncVouchers($voucherCodes));
+        if (empty($errors)) {
+            // TODO: trigger payment transition on $bundle
         }
 
-        // --- Disburse if collection details are present ---
-        if ($request->filled(['collected_at', 'collected_by', 'collected_on'])) {
-            if ($bundle->vouchers->isEmpty()) {
-                $errors['empty'] = true;
-            } else {
-                $errors = array_merge_recursive(
-                    $errors,
-                    $this->disburseBundle($bundle, $request->only(['collected_at', 'collected_by', 'collected_on'])),
-                );
-
-                if (empty($errors)) {
-                    $successRoute = route('store.registration.index');
-                }
-            }
-        }
+        $successRoute = empty($errors) ? route('store.registration.index') : $managerRoute;
 
         return $this->redirectAfterRequest($errors, $successRoute, $managerRoute, $bundle);
     }
@@ -167,9 +166,24 @@ class BundleController extends Controller
     }
 
     /**
+     * Guard against an empty bundle then delegate to disburseBundle.
+     * Returns an error map on failure, or an empty array on success.
+     */
+    private function attemptDisbursal(Bundle $bundle, array $inputs): array
+    {
+        if ($bundle->vouchers->isEmpty()) {
+            return ['empty' => true];
+        }
+
+        return ($this->disburseBundle($bundle, $inputs))
+            ? ['transaction' => true]
+            : [];
+    }
+
+    /**
      * Attempt to mark a bundle as disbursed.
      */
-    private function disburseBundle(Bundle $bundle, array $inputs): array
+    private function disburseBundle(Bundle $bundle, array $inputs): bool
     {
         try {
             $bundle->disbursed_at = Carbon::createFromFormat('Y-m-d', $inputs['collected_on'])
@@ -179,8 +193,6 @@ class BundleController extends Controller
             $bundle->disbursingCentre()->associate(Centre::findOrFail($inputs['collected_at']));
             $bundle->disbursingUser()->associate(Auth::user());
             $bundle->save();
-
-            return [];
         } catch (Throwable $e) {
             Log::error(sprintf(
                 'Bad transaction for %s@%s by service user %s',
@@ -189,9 +201,9 @@ class BundleController extends Controller
                 Auth::id() ?? 'unauthenticated',
             ));
             Log::error($e->getTraceAsString());
-
-            return ['transaction' => true];
+            return false;
         }
+        return true;
     }
 
     /**
@@ -305,12 +317,5 @@ class BundleController extends Controller
             Str::plural('voucher', $count),
             $name,
         );
-    }
-
-    /**
-     *
-     */
-    public function requestPayment(Request $request) {
-        //
     }
 }

--- a/app/Http/Controllers/Store/BundleController.php
+++ b/app/Http/Controllers/Store/BundleController.php
@@ -102,7 +102,7 @@ class BundleController extends Controller
     /**
      * Disburse the current bundle if collection details are present.
      */
-    public function update(StorePickupBundleRequest $request, Registration $registration): RedirectResponse
+    public function pickup(StorePickupBundleRequest $request, Registration $registration): RedirectResponse
     {
         $managerRoute = $this->managerRoute($registration);
         $bundle = $registration->currentBundle();

--- a/app/Http/Requests/StoreAppendBundleRequest.php
+++ b/app/Http/Requests/StoreAppendBundleRequest.php
@@ -8,11 +8,9 @@ use Illuminate\Foundation\Http\FormRequest;
 class StoreAppendBundleRequest extends FormRequest
 {
     /**
-     * Determine if the user is authorized to make this request.
-     *
-     * @return bool
+     * Determine if the user is authorized to make this request
      */
-    public function authorize()
+    public function authorize(): true
     {
         // TODO : determine of existing registration route protection is sufficient.
         return true;
@@ -20,38 +18,51 @@ class StoreAppendBundleRequest extends FormRequest
 
     /**
      * Get the validation rules that apply to the request.
-     *
-     * @return array
      */
-    public function rules()
+    public function rules(): array
     {
         /*
          * These rules validate that the form data is well-formed.
          * It is NOT responsible for the context validation of that data.
          */
-        $rules = [
-            // MUST be present, not null and string
-            'start' => 'required|string|exists:vouchers,code',
-            // MAY be present, nullable, string, code exists, is GT start and same sponsor as start
-            'end' => 'nullable|string|exists:vouchers,code|codeGreaterThan:start|sameSponsor:start',
+        return [
+            'voucher-quantity' => [
+                'nullable',
+                'integer',
+                'between:1,' . config('arc.bundle_max_voucher_append'),
+                'required_without:start',
+            ],
+            'start' => [
+                'exclude_if:voucher-quantity,present',
+                'required_without:voucher-quantity',
+                'string',
+                'exists:vouchers,code',
+            ],
+            'end' => [
+                'exclude_if:voucher-quantity,present',
+                'nullable',
+                'string',
+                'exists:vouchers,code',
+                'codeGreaterThan:start',
+                'sameSponsor:start',
+            ],
         ];
-
-        return $rules;
     }
 
-    protected function prepareForValidation()
+    protected function prepareForValidation(): void
     {
-        // get the input and remove null/empty values.
-        $input = array_filter(
-            $this->all(['start', 'end']),
-            'strlen'
-        );
+        if ($this->filled('voucher-quantity')) {
+            $this->replace(['voucher-quantity' => (int)$this->input('voucher-quantity')]);
+            return;
+        }
+
+        $input = array_filter($this->all(['start', 'end']), 'strlen');
 
         foreach ($input as $key => $value) {
             $clean = Voucher::cleanCodes((array)$value);
-            $input[$key] = strtoupper((array_shift($clean)));
+            $input[$key] = strtoupper(array_shift($clean));
         }
-        // replace old input with new input
+
         $this->replace($input);
     }
 }

--- a/app/Http/Requests/StorePickupBundleRequest.php
+++ b/app/Http/Requests/StorePickupBundleRequest.php
@@ -4,7 +4,7 @@ namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
 
-class StoreUpdateBundleRequest extends FormRequest
+class StorePickupBundleRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -26,10 +26,9 @@ class StoreUpdateBundleRequest extends FormRequest
          * It is NOT responsible for the context validation of that data.
          */
         return [
-            // Mutually dependent
-            'collected_on' => 'required_with_all:collected_at,collected_by|date_format:Y-m-d',
-            'collected_at' => 'integer|required_with_all:collected_on,collected_by|exists:centres,id',
-            'collected_by' => 'integer|required_with_all:collected_at,collected_on|exists:carers,id'
+            'collected_on' => 'required|date_format:Y-m-d',
+            'collected_at' => 'required|integer|exists:centres,id',
+            'collected_by' => 'required|integer|exists:carers,id'
         ];
     }
 }

--- a/app/Http/Requests/StoreRequestPaymentRequest.php
+++ b/app/Http/Requests/StoreRequestPaymentRequest.php
@@ -4,7 +4,7 @@ namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
 
-class StoreUpdateBundleRequest extends FormRequest
+class StoreRequestPaymentRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.

--- a/app/Http/Requests/StoreTransitionBundleRequest.php
+++ b/app/Http/Requests/StoreTransitionBundleRequest.php
@@ -4,7 +4,7 @@ namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
 
-class StoreRequestPaymentRequest extends FormRequest
+class StoreTransitionBundleRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -26,10 +26,10 @@ class StoreRequestPaymentRequest extends FormRequest
          * It is NOT responsible for the context validation of that data.
          */
         return [
-            // Mutually dependent
-            'collected_on' => 'required_with_all:collected_at,collected_by|date_format:Y-m-d',
-            'collected_at' => 'integer|required_with_all:collected_on,collected_by|exists:centres,id',
-            'collected_by' => 'integer|required_with_all:collected_at,collected_on|exists:carers,id'
+            'collected_on' => 'required|date_format:Y-m-d',
+            'collected_at' => 'required|integer|exists:centres,id',
+            'collected_by' => 'required|exists:carers,id',
+            'trader_id' => 'required|integer|exists:traders,id'
         ];
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use App\CentreUser;
 use App\Services\EnvWriter;
 use App\View\Composers\PaymentsComposer;
 use Illuminate\Pagination\Paginator;
@@ -38,6 +39,21 @@ class AppServiceProvider extends ServiceProvider
         Gate::define('take-developer-actions', static function () {
             // permit if the application is debugging
             return config('app.debug') === true;
+        });
+
+        Gate::define('collect-vouchers', static function (CentreUser $centreUser) {
+            $centreId = session('CentreUserCurrentCentreId');
+
+            if (! $centreId) {
+                return false;
+            }
+
+            // is this user permitted to work on this can_collect centre?
+            return $centreUser
+                ->centres()
+                ->where('centres.id', $centreId)
+                ->where('centres.can_collect', true)
+                ->exists();
         });
     }
 

--- a/app/Registration.php
+++ b/app/Registration.php
@@ -129,10 +129,8 @@ class Registration extends Model implements IEvaluee
     /**
      * Get the first un-disbursed bundle on a Registration for any Centre.
      * There should only be one... else make one if there are none.
-     *
-     * @return Model
      */
-    public function currentBundle(): Model
+    public function currentBundle(): Bundle
     {
         $bundle = $this->bundles()
             ->where('disbursed_at', null)

--- a/app/Services/TransitionProcessor.php
+++ b/app/Services/TransitionProcessor.php
@@ -35,67 +35,86 @@ class TransitionProcessor
 
     private string $transition;
 
-    /**
-     * @param Trader $trader
-     * @param string $transition
-     */
-    public function __construct(trader $trader, string $transition)
+    public function __construct(Trader $trader, string $transition)
     {
         $this->transition = $transition;
         $this->trader = $trader;
     }
 
     /**
-     * Preps and picks a strategy for transitioning vouchers
-     * @param array $voucherCodes
-     * @return array|array[]
+     * Preps and picks a strategy for transitioning vouchers.
+     *
+     * Accepts either an array of voucher code strings, or a pre-resolved
+     * Collection of Voucher models (e.g. when called from an HTTP controller
+     * that has already fetched the models).
      */
-    public function handle(array $voucherCodes): array
+    public function handle(array|Collection $input): array
     {
-        // set a lock, to prevent double submits
         $store = new SemaphoreStore();
         $factory = new LockFactory($store);
         $lock = $factory->createLock('transition');
 
-        \Log::debug("Acquiring lock for vouchers " . join(", ", $voucherCodes));
+        Log::debug("Acquiring lock for vouchers " . $this->describeInput($input));
+
         if ($lock->acquire()) {
-            // get and the available vouchers
-            $this->vouchers = Voucher::findByCodes($voucherCodes);
+            $this->resolveVouchers($input);
 
-            // Get the ones not in that list - they are bad codes.
-            // We need to re-key the array here because otherwise the json response will return object for non 0 starting.
-            $this->responses['invalid'] = array_values(
-                array_diff(
-                    $voucherCodes,
-                    $this->vouchers->pluck('code')->toArray()
-                )
-            );
-
-            switch ($this->transition) {
-                case 'collect' :
-                    $this->handleCollect();
-                    break;
-                case 'confirm':
-                    $this->handleConfirm();
-                    break;
-                case 'reject':
-                    $this->handleReject();
-                    break;
-                default:
-                    $this->handleDefault();
-            }
+            match ($this->transition) {
+                'collect' => $this->handleCollect(),
+                'confirm' => $this->handleConfirm(),
+                'reject' => $this->handleReject(),
+                default => $this->handleDefault()
+            };
 
             $lock->release();
         } else {
-            Log::info("Unable to achieve lock in transition processor for { $this->trader->id } doing $this->transition");
+            Log::info(sprintf(
+                "Unable to achieve lock in transition processor for %s doing %s",
+                $this->trader->id,
+                $this->transition
+            ));
             $this->responses['own_duplicate'][] = '000000';
         }
+
         return $this->responses;
     }
 
     /**
+     * Resolves the input into $this->vouchers, handling two cases:
+     */
+    private function resolveVouchers(array|Collection $input): void
+    {
+        if ($input instanceof Collection) {
+            $this->vouchers = $input;
+            return;
+        }
+
+        // Code array path: resolve models and detect any unrecognised codes.
+        $this->vouchers = Voucher::findByCodes($input);
+
+        // Re-keyed so the JSON response always returns an array, not an object.
+        $this->responses['invalid'] = array_values(
+            array_diff(
+                $input,
+                $this->vouchers->pluck('code')->toArray()
+            )
+        );
+    }
+
+    /**
+     * Returns a loggable summary of whichever input form was supplied.
+     */
+    private function describeInput(array|Collection $input): string
+    {
+        if ($input instanceof Collection) {
+            return $input->pluck('code')->implode(', ');
+        }
+
+        return implode(', ', $input);
+    }
+
+    /**
      * handles collection vouchers
-     * @return void
      */
     public function handleCollect(): void
     {
@@ -104,7 +123,7 @@ class TransitionProcessor
         $transition = $this->transition;
 
         foreach ($this->vouchers as $voucher) {
-            \Log::debug("handleCollect on voucher " . $voucher->code);
+            Log::debug("handleCollect on voucher " . $voucher->code);
             // Don't transition newer, undelivered vouchers
             if (// delivery_id is null
                 $voucher->delivery_id === null &&
@@ -113,7 +132,7 @@ class TransitionProcessor
             ) {
                 // Don't proceed, just file this voucher for a message
                 $this->responses['undelivered'][] = $voucher->code;
-                \Log::debug("Undelivered voucher " . $voucher->code);
+                Log::debug("Undelivered voucher " . $voucher->code);
                 continue;
             }
 
@@ -125,10 +144,6 @@ class TransitionProcessor
 
     /**
      * Actually does the transition - will save a voucher on the way through
-     * @param Voucher $voucher
-     * @param string $transition
-     * @param int|null $againstTraderId
-     * @return bool
      */
     private function doTransition(Voucher $voucher, string $transition, ?int $againstTraderId = null): bool
     {
@@ -136,18 +151,28 @@ class TransitionProcessor
             if ($voucher->transitionAllowed($transition)) {
                 $voucher->trader_id = $againstTraderId;
                 $voucher->applyTransition($transition);
-                \Log::debug(sprintf("Transition %s on %s for %d", $transition, $voucher, $againstTraderId));
+                Log::debug(sprintf("Transition %s on %s for %d", $transition, $voucher, $againstTraderId));
             } else {
                 // No? drop vouchers into a relevant bin
                 if ($voucher->trader_id === $againstTraderId) {
                     // Trader has already submitted this voucher
                     $this->responses['own_duplicate'][] = $voucher->code;
-                    \Log::debug(sprintf("Transition denied %s on %s for %d, own_duplicate", $transition, $voucher, $againstTraderId));
+                    Log::debug(sprintf(
+                        "Transition denied %s on %s for %d, own_duplicate",
+                        $transition,
+                        $voucher,
+                        $againstTraderId
+                    ));
                 } else {
                     // Another trader has mistakenly submitted this voucher,
                     // Or the transition isn't valid (i.e. expired state)
                     $this->responses['other_duplicate'][] = $voucher->code;
-                    \Log::debug(sprintf("Transition denied %s on %s for %d, other_duplicate", $transition, $voucher, $againstTraderId));
+                    Log::debug(sprintf(
+                        "Transition denied %s on %s for %d, other_duplicate",
+                        $transition,
+                        $voucher,
+                        $againstTraderId
+                    ));
                 }
                 return false;
             }
@@ -161,7 +186,6 @@ class TransitionProcessor
 
     /**
      * confirms a voucher set for payment
-     * @return void
      */
     public function handleConfirm(): void
     {
@@ -172,7 +196,6 @@ class TransitionProcessor
         $transition = $this->transition;
 
         foreach ($this->vouchers as $voucher) {
-
             // Can we do a transition already?
             if ($this->doTransition($voucher, $transition, $this->trader->id)) {
                 // add to a list for sending to ARC admin. This is a request for payment.
@@ -191,9 +214,6 @@ class TransitionProcessor
 
     /**
      * Email a Trader's Voucher Payment Request.
-     * @param Trader $trader
-     * @param array $vouchers
-     * @return void
      */
     public static function emailVoucherPaymentRequest(Trader $trader, array $vouchers): void
     {
@@ -209,7 +229,6 @@ class TransitionProcessor
 
     /**
      * This handles rejections back to the free voucher pool
-     * @return void
      */
     public function handleReject(): void
     {
@@ -233,7 +252,6 @@ class TransitionProcessor
 
     /**
      * This is for undefined transitions, as a catchall.
-     * @return void
      */
     public function handleDefault(): void
     {
@@ -246,7 +264,6 @@ class TransitionProcessor
 
     /**
      * Helper to construct voucher validation response messages.
-     * @return array
      */
     public function constructResponseMessage(): array
     {

--- a/app/Services/TransitionProcessor.php
+++ b/app/Services/TransitionProcessor.php
@@ -9,6 +9,7 @@ use App\Trader;
 use App\Voucher;
 use Carbon\Carbon;
 use Exception;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
@@ -327,5 +328,25 @@ class TransitionProcessor
                 'invalid_amount' => count($responses['invalid']) + count($responses['undelivered']),
             ]),
         ];
+    }
+
+    /**
+     * Works out if we had any type of voucher transition failure
+     */
+    public function hasFailures(): bool
+    {
+        return (bool) Arr::first(
+            Arr::except($this->responses, 'success_add'),
+            static function (array $failureType) {
+                return !empty($failureType);
+            }
+        );
+    }
+
+    public function getFailureCodes(): array
+    {
+        return ($this->hasFailures())
+            ? Arr::flatten(Arr::except($this->responses, 'success_add'))
+            : [];
     }
 }

--- a/app/StateToken.php
+++ b/app/StateToken.php
@@ -2,13 +2,15 @@
 
 namespace App;
 
-use DB;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Eloquent\Relations\HasOne;
-use Ramsey\Uuid\Uuid;
-use Log;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Str;
+
 /**
+ * @property string $uuid
+ * @property int|null $user_id
+ * @property int|null $admin_user_id
  * @property VoucherState $voucherStates
  * @property User $user
  * @property AdminUser $adminUser
@@ -17,8 +19,6 @@ class StateToken extends Model
 {
     /**
      * The attributes that are mass assignable.
-     *
-     * @var array
      */
     protected $fillable = [
         'uuid',
@@ -27,63 +27,43 @@ class StateToken extends Model
     ];
 
     /**
-     * The attributes that should be hidden for arrays.
-     *
-     * @var array
+     * The attributes that should be cast.
      */
-    protected $hidden = [
+    protected $casts = [
+        'user_id' => 'integer',
+        'admin_user_id' => 'integer',
     ];
 
     /**
-     * Makes and checks for an unused token
-     *
-     * @return string
-    */
-    public static function generateUnusedToken()
+     * Generate a unique, unused UUID token.
+     */
+    public static function generateUnusedToken(): string
     {
         do {
-            // TODO: Deal with possibility uuid4() may throw an exception of it's own?
-            try {
-                $candidate = Uuid::uuid4()->toString();
-            } catch (\Exception $e) {
-                // Uuid4() throws exceptions, apparently! Log that and die, I guess?
-                Log::warning($e->getMessage());
-                abort(500, $e->getMessage());
-            }
-            // Check if it's in use.
-            $usedToken = self::isUsedToken($candidate);
-        } while ($usedToken === true);
+            $candidate = Str::uuid()->toString();
+        } while (static::isUsedToken($candidate));
 
         return $candidate;
     }
 
     /**
-     * Checks a UUID has been used
-     * @param $candidate
-     * @return bool
+     * Check whether a UUID token is already in use.
      */
-    public static function isUsedToken($candidate)
+    public static function isUsedToken(string $candidate): bool
     {
-        $tableName = 'state_tokens';
-        return DB::table($tableName)
-            ->where('uuid', $candidate)
-            ->exists();
+        return static::where('uuid', $candidate)->exists();
     }
 
     /**
-     * The vouchers that share this StateToken
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     * The voucher states that share this StateToken.
      */
-    public function voucherStates()
+    public function voucherStates(): HasMany
     {
         return $this->hasMany(VoucherState::class);
     }
 
     /**
-     * The user that created this StateToken
-     *
-     * @return BelongsTo
+     * The user that created this StateToken.
      */
     public function user(): BelongsTo
     {
@@ -91,9 +71,7 @@ class StateToken extends Model
     }
 
     /**
-     * The admin user that updated this StateToken
-     *
-     * @return BelongsTo
+     * The admin user associated with this StateToken.
      */
     public function adminUser(): BelongsTo
     {

--- a/app/Voucher.php
+++ b/app/Voucher.php
@@ -14,6 +14,7 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Collection;
 use Log;
+use RuntimeException;
 use Throwable;
 
 /**
@@ -313,7 +314,7 @@ class Voucher extends Model
 
                     LEFT JOIN vouchers as v2
                         ON final_id = v2.id
-                        
+
                     ORDER BY t1.start
                     "
                 );
@@ -586,5 +587,30 @@ class Voucher extends Model
             $v["vouchere_states"] = $this->getVoucherStateHistory();
         }
         return $v;
+    }
+
+    /**
+     * Claim the first $quantity available (printed, unallocated) vouchers from the pool.
+     * Uses a pessimistic lock to prevent concurrent allocation of the same vouchers.
+     * @throws Throwable
+     */
+    public static function claimFromPool(int $quantity): Collection
+    {
+        return DB::transaction(static function () use ($quantity) {
+            $vouchers = self::where('currentstate', 'printed')
+                ->whereNull('bundle_id')
+                ->orderBy('id')
+                ->limit($quantity)
+                ->lockForUpdate()
+                ->get();
+
+            if ($vouchers->count() < $quantity) {
+                throw new RuntimeException(
+                    "Pool has {$vouchers->count()} vouchers available, {$quantity} requested."
+                );
+            }
+
+            return $vouchers;
+        });
     }
 }

--- a/public/store/css/main.css
+++ b/public/store/css/main.css
@@ -1361,16 +1361,9 @@ VOUCHER PAGES
     margin-right: 2rem;
 }
 
-.pick-up select,
-.pick-up input {
-    width: 100%;
-    max-width: 200px;
-}
-
 .pick-up input {
     margin-top: 0.5rem;
     border: 1px solid #a6a6a6;
-    max-width: 180px;
     padding: 0.5rem;
     font-family: Lato, 'Helvetica Neue', Helvetica, Arial, sans-serif;
 }

--- a/public/store/css/main.css
+++ b/public/store/css/main.css
@@ -56,6 +56,7 @@ input.uppercase {
 }
 
 input[type="text"],
+input[type="number"],
 input[type="month"],
 input[type="search"],
 input[type="email"],
@@ -1245,6 +1246,7 @@ VOUCHER PAGES
     line-height: 2.2rem;
     margin-left: 0.2rem;
     width: 2.2rem;
+    text-align: center;
 }
 
 .col .alert-message {

--- a/resources/views/store/manage_vouchers.blade.php
+++ b/resources/views/store/manage_vouchers.blade.php
@@ -9,8 +9,14 @@
         <div class="col-container">
             @include('store.voucher-manager.family-info')
             @include('store.voucher-manager.collection-history')
-            @include('store.voucher-manager.allocate-vouchers')
-            @include('store.voucher-manager.pickup')
+
+            @can('collect-vouchers')
+                @include('store.voucher-manager.allocate-vouchers-numeric')
+                @include('store.voucher-manager.collect')
+            @else
+                @include('store.voucher-manager.allocate-vouchers')
+                @include('store.voucher-manager.pickup')
+            @endcan
         </div>
     </div>
 @endsection

--- a/resources/views/store/voucher-manager/allocate-vouchers-numeric.blade.php
+++ b/resources/views/store/voucher-manager/allocate-vouchers-numeric.blade.php
@@ -34,8 +34,10 @@
     </button>
 
     <div class="center" id="vouchers-added">
-        <span class="emphasised-section">Vouchers added</span>
-        <span class="number-circle">{{ $vouchers_amount }}</span>
+        <div id="vouchers-total">
+            <span class="emphasised-section">Vouchers added</span>
+            <span class="number-circle">{{ $vouchers_amount }}</span>
+        </div>
 
         <div @class(['collapsed' => $vouchers_amount === 0])>
             <form
@@ -94,7 +96,7 @@
             });
 
             if ($('#vouchers tr').length > 1) { // first tr is the header
-                $('#vouchers-added').addClass('pulse');
+                $('#vouchers-total').addClass('pulse');
             }
 
             $('#voucher-quantity').keypress(function (e) {

--- a/resources/views/store/voucher-manager/allocate-vouchers-numeric.blade.php
+++ b/resources/views/store/voucher-manager/allocate-vouchers-numeric.blade.php
@@ -1,0 +1,110 @@
+{{-- Requires: $registration, $vouchers, $vouchers_amount, $entitlement, $errors --}}
+<div class="col allocation">
+    <div>
+        <img src="{{ asset('store/assets/allocation-light.svg') }}">
+        <h2 id="allocate-vouchers">Allocate Vouchers</h2>
+    </div>
+
+    {{-- Quantity entry --}}
+    <form method="POST" action="{{ route('store.registration.vouchers.post', ['registration' => $registration->id]) }}">
+        @csrf
+        <div class="single-container">
+            <label for="voucher-quantity">Number of vouchers
+                <input
+                    id="voucher-quantity"
+                    name="voucher-quantity"
+                    type="number"
+                    min="1"
+                    max="{{ config('arc.bundle_max_voucher_append') }}"
+                    value="{{ $entitlement }}"
+                    autocomplete="off"
+                >
+            </label>
+            <button id="quantity-add" class="add-button" type="submit" name="quantity-add">
+                <i class="fa fa-plus" aria-hidden="true"></i>
+            </button>
+        </div>
+    </form>
+
+    @includeWhen($errors->count() > 0, 'store.partials.errors', ['error_array' => $errors->all()])
+    @includeWhen(Session::get('error_messages'), 'store.partials.errors', ['error_array' => Session::get('error_messages')])
+
+    <button id="collection-button" class="long-button" @disabled($vouchers_amount == 0)>
+        <i class="fa fa-ticket button-icon" aria-hidden="true"></i>Go to voucher collection
+    </button>
+
+    <div class="center" id="vouchers-added">
+        <span class="emphasised-section">Vouchers added</span>
+        <span class="number-circle">{{ $vouchers_amount }}</span>
+
+        <div @class(['collapsed' => $vouchers_amount === 0])>
+            <form
+                id="unbundle-all"
+                name="unbundle-all"
+                method="POST"
+                action="{{ route('store.registration.vouchers.delete', ['registration' => $registration->id]) }}"
+                class="delete-button remove-all-container"
+            >
+                @method('DELETE')
+                @csrf
+                <button type="submit" name="delete-all-button" id="delete-all-button">
+                    <i class="fa fa-trash" aria-hidden="true"></i> Remove all added vouchers
+                </button>
+            </form>
+        </div>
+
+        <div id="vouchers" @class(['collapsed' => $vouchers_amount === 0])>
+            <form id="unbundle" name="unbundle" method="POST">
+                @method('DELETE')
+                @csrf
+                <table>
+                    <tr>
+                        <th>Voucher code</th>
+                        <th>Remove</th>
+                    </tr>
+                    @foreach($vouchers as $voucher)
+                        <tr>
+                            <td>{{ $voucher->code }}</td>
+                            <td>
+                                <button
+                                    type="submit"
+                                    class="delete-button"
+                                    name="delete-button"
+                                    id="{{ $voucher->id }}"
+                                    formaction="{{ route('store.registration.voucher.delete', ['registration' => $registration->id, 'voucher' => $voucher->id]) }}"
+                                >
+                                    <i class="fa fa-minus" aria-hidden="true"></i>
+                                </button>
+                            </td>
+                        </tr>
+                    @endforeach
+                </table>
+            </form>
+        </div>
+    </div>
+</div>
+
+@pushonce('js')
+    <script>
+        $(document).ready(function () {
+            $('#collection-button').click(function (e) {
+                e.preventDefault();
+                $('#collection').addClass('slide-in');
+                $('.allocation').addClass('fade-back');
+            });
+
+            if ($('#vouchers tr').length > 1) { // first tr is the header
+                $('#vouchers-added').addClass('pulse');
+            }
+
+            $('#voucher-quantity').keypress(function (e) {
+                if (e.keyCode !== 13) return;
+                e.preventDefault();
+                window.setTimeout(function () {
+                    $('#quantity-add').trigger('click');
+                }, 200);
+            });
+        });
+    </script>
+@endpushonce
+

--- a/resources/views/store/voucher-manager/allocate-vouchers.blade.php
+++ b/resources/views/store/voucher-manager/allocate-vouchers.blade.php
@@ -94,10 +94,9 @@
     </div>
 </div>
 
-@pushonce('scripts')
+@pushonce('js')
     <script>
         $(document).ready(function () {
-
             $('#collection-button').click(function (e) {
                 e.preventDefault();
                 $('#collection').addClass('slide-in');

--- a/resources/views/store/voucher-manager/allocate-vouchers.blade.php
+++ b/resources/views/store/voucher-manager/allocate-vouchers.blade.php
@@ -44,9 +44,10 @@
     </button>
 
     <div class="center" id="vouchers-added">
-        <span class="emphasised-section">Vouchers added</span>
-        <span class="number-circle">{{ $vouchers_amount }}</span>
-
+        <div id="vouchers-total">
+            <span class="emphasised-section">Vouchers added</span>
+            <span class="number-circle">{{ $vouchers_amount }}</span>
+        </div>
         <div @class(['collapsed' => $vouchers_amount === 0])>
             <form
                 id="unbundle-all"
@@ -104,7 +105,7 @@
             });
 
             if ($('#vouchers tr').length > 1) { // first tr is the header
-                $('#vouchers-added').addClass('pulse');
+                $('#vouchers-total').addClass('pulse');
             }
 
             var delay = 200;

--- a/resources/views/store/voucher-manager/collect.blade.php
+++ b/resources/views/store/voucher-manager/collect.blade.php
@@ -1,0 +1,92 @@
+{{-- Requires: $programme, $registration, $vouchers_amount, $carers, $centre --}}
+<div id="collection" class="col collection-section">
+    <div>
+        <i class="fa fa-shopping-basket fa-3x" style="margin: 0 0.5rem;" ></i>
+        <h2>Request Payment</h2>
+    </div>
+
+    <div>
+        <p>There's <span class="number-circle">{{ $vouchers_amount }}</span> @choice('{1}voucher|[0,2,*]vouchers', $vouchers_amount) waiting for this {{ $programme === 0 ? 'family' : 'household' }}</p>
+    </div>
+
+    <form
+        method="POST"
+        action="{{ route('store.registration.vouchers.payment-requests.post', ['registration' => $registration->id]) }}"
+    >
+        @method('PUT')
+        @csrf
+        <div class="pick-up">
+            <div>
+                <i class="fa fa-user"></i>
+                <div>
+                    <label for="requested-by">Request for:</label>
+                    <select id="requested-by" name="requested_by">
+                        @foreach($carers as $carer)
+                            <option value="{{ $carer->id }}">{{ $carer->name }}</option>
+                        @endforeach
+                    </select>
+                </div>
+            </div>
+
+            <div>
+                <i class="fa fa-calendar"></i>
+                <div>
+                    <label for="requested-on">Request on:</label>
+                    <div id="dateError" style="display:none;"></div>
+                    <input
+                        id="requested-on"
+                        name="requested_on"
+                        value="{{ now()->format('Y-m-d') }}"
+                        type="date"
+                    >
+                </div>
+            </div>
+
+            <div>
+                <i class="fa fa-home"></i>
+                <div>
+                    <label for="requested-at">Request at: {{ $centre->name }}</label>
+                    <input type="hidden" id="requested-at" name="requested_at" value="{{ $centre->id }}">
+                </div>
+            </div>
+
+            <button id="collection-button" class="long-button submit" type="submit" @disabled($vouchers_amount === 0)>
+                Request Payment
+            </button>
+        </div>
+    </form>
+
+    <x-link-button
+        href="{{ route('store.registration.voucher-manager', ['registration' => $registration->id]) }}"
+        icon="ticket"
+    >
+        Change allocated vouchers
+    </x-link-button>
+</div>
+
+@pushonce('scripts')
+    <script>
+        $(document).ready(function () {
+            var requestedOn = $('#requested-on');
+            if (requestedOn[0].type !== 'date') {
+                requestedOn.datepicker({dateFormat: 'yy-mm-dd'}).val();
+            }
+            requestedOn.valueAsDate = new Date();
+
+            requestedOn.change(function () {
+                var chosen = new Date($(this).val());
+                var cutoff = new Date();
+                cutoff.setDate(cutoff.getDate() + 42); // six weeks
+
+                if (chosen > cutoff) {
+                    $('#dateError')
+                        .text('Please choose a date within six weeks of today')
+                        .css({fontSize: '12px', color: 'red'})
+                        .show();
+                } else {
+                    $('#dateError').hide();
+                }
+            });
+        });
+    </script>
+@endpushonce

--- a/resources/views/store/voucher-manager/collect.blade.php
+++ b/resources/views/store/voucher-manager/collect.blade.php
@@ -11,7 +11,7 @@
 
     <form
         method="POST"
-        action="{{ route('store.registration.vouchers.payment-requests.post', ['registration' => $registration->id]) }}"
+        action="{{ route('store.registration.vouchers.transitions.collect', ['registration' => $registration->id]) }}"
     >
         @method('PUT')
         @csrf

--- a/resources/views/store/voucher-manager/collect.blade.php
+++ b/resources/views/store/voucher-manager/collect.blade.php
@@ -19,8 +19,8 @@
             <div>
                 <i class="fa fa-user"></i>
                 <div>
-                    <label for="requested-by">Request for:</label>
-                    <select id="requested-by" name="requested_by">
+                    <label for="collected-by">Request for:</label>
+                    <select id="collected-by" name="collected_by">
                         @foreach($carers as $carer)
                             <option value="{{ $carer->id }}">{{ $carer->name }}</option>
                         @endforeach
@@ -31,11 +31,11 @@
             <div>
                 <i class="fa fa-calendar"></i>
                 <div>
-                    <label for="requested-on">Request on:</label>
+                    <label for="collected-on">Request on:</label>
                     <div id="dateError" style="display:none;"></div>
                     <input
-                        id="requested-on"
-                        name="requested_on"
+                        id="collected-on"
+                        name="collected_on"
                         value="{{ now()->format('Y-m-d') }}"
                         type="date"
                     >
@@ -45,8 +45,8 @@
             <div>
                 <i class="fa fa-home"></i>
                 <div>
-                    <label for="requested-at">Request at: {{ $centre->name }}</label>
-                    <input type="hidden" id="requested-at" name="requested_at" value="{{ $centre->id }}">
+                    <label for="collected-at">Request at: {{ $centre->name }}</label>
+                    <input type="hidden" id="collected-at" name="collected_at" value="{{ $centre->id }}">
                 </div>
             </div>
 
@@ -67,13 +67,13 @@
 @pushonce('scripts')
     <script>
         $(document).ready(function () {
-            var requestedOn = $('#requested-on');
-            if (requestedOn[0].type !== 'date') {
-                requestedOn.datepicker({dateFormat: 'yy-mm-dd'}).val();
+            var collectedOn = $('#collected-on');
+            if (collectedOn[0].type !== 'date') {
+                collectedOn.datepicker({dateFormat: 'yy-mm-dd'}).val();
             }
-            requestedOn.valueAsDate = new Date();
+            collectedOn.valueAsDate = new Date();
 
-            requestedOn.change(function () {
+            collectedOn.change(function () {
                 var chosen = new Date($(this).val());
                 var cutoff = new Date();
                 cutoff.setDate(cutoff.getDate() + 42); // six weeks

--- a/resources/views/store/voucher-manager/collect.blade.php
+++ b/resources/views/store/voucher-manager/collect.blade.php
@@ -19,7 +19,7 @@
             <div>
                 <i class="fa fa-user"></i>
                 <div>
-                    <label for="collected-by">Request for:</label>
+                    <label for="collected-by">Transact with:</label>
                     <select id="collected-by" name="collected_by">
                         @foreach($carers as $carer)
                             <option value="{{ $carer->id }}">{{ $carer->name }}</option>
@@ -31,7 +31,7 @@
             <div>
                 <i class="fa fa-calendar"></i>
                 <div>
-                    <label for="collected-on">Request on:</label>
+                    <label for="collected-on">Transact on:</label>
                     <div id="dateError" style="display:none;"></div>
                     <input
                         id="collected-on"
@@ -45,13 +45,29 @@
             <div>
                 <i class="fa fa-home"></i>
                 <div>
-                    <label for="collected-at">Request at: {{ $centre->name }}</label>
+                    <label for="collected-at">Transact at: {{ $centre->name }}</label>
                     <input type="hidden" id="collected-at" name="collected_at" value="{{ $centre->id }}">
                 </div>
             </div>
 
+            <div>
+                <i class="fa fa-shopping-cart"></i>
+                <div>
+                    <label for="collected-as">Transact as:</label>
+                    <select id="collected-as" name="trader_id">
+                        @foreach($centre->markets as $market)
+                            <optgroup label="{{ $market->name }}">
+                                @foreach($market->traders as $trader)
+                                    <option value="{{ $trader->id }}">{{ $trader->name }}</option>
+                                @endforeach
+                            </optgroup>
+                        @endforeach
+                    </select>
+                </div>
+            </div>
+
             <button id="collection-button" class="long-button submit" type="submit" @disabled($vouchers_amount === 0)>
-                Request Payment
+                Confirm Transaction
             </button>
         </div>
     </form>

--- a/resources/views/store/voucher-manager/pickup.blade.php
+++ b/resources/views/store/voucher-manager/pickup.blade.php
@@ -6,8 +6,7 @@
     </div>
 
     <div>
-        <p>There are {{ $vouchers_amount }} vouchers waiting for
-            this {{ $programme === 0 ? 'family' : 'household' }}</p>
+        <p>There's <span class="number-circle">{{ $vouchers_amount }}</span> @choice('{1}voucher|[0,2,*]vouchers', $vouchers_amount) waiting for this {{ $programme === 0 ? 'family' : 'household' }}</p>
     </div>
 
     <form
@@ -51,7 +50,7 @@
                 </div>
             </div>
 
-            <button class="long-button submit" type="submit" @disabled($vouchers_amount === 0)>
+            <button id="collection-button" class="long-button submit" type="submit" @disabled($vouchers_amount === 0)>
                 Confirm pick up
             </button>
         </div>

--- a/routes/store.php
+++ b/routes/store.php
@@ -38,7 +38,7 @@ Route::get('/', static function () {
 })->name('store.base');
 
 // Authenticated routes
-Route::middleware('auth:store')->group(function () {
+Route::middleware('auth:store')->group(function (): void {
 
     Route::post('logout', [LoginController::class, 'logout'])
         ->name('store.logout');
@@ -117,6 +117,12 @@ Route::middleware('auth:store')->group(function () {
 
         Route::post('/registrations/{registration}/vouchers', [BundleController::class, 'addVouchersToCurrentBundle'])
             ->name('store.registration.vouchers.post')
+            ->whereNumber('registration');
+
+        Route::post('/registrations/{registration}/vouchers/payment-requests',
+            [BundleController::class, 'requestPayment']
+        )
+            ->name('store.registration.vouchers.payment-requests.post')
             ->whereNumber('registration');
     });
 

--- a/routes/store.php
+++ b/routes/store.php
@@ -120,10 +120,10 @@ Route::middleware('auth:store')->group(function (): void {
             ->whereNumber('registration');
 
         Route::post(
-            '/registrations/{registration}/vouchers/payment-requests',
-            [BundleController::class, 'requestPayment']
+            '/registrations/{registration}/vouchers/transitions/collection',
+            [BundleController::class, 'collectBundle']
         )
-            ->name('store.registration.vouchers.payment-requests.post')
+            ->name('store.registration.vouchers.transitions.collect')
             ->whereNumber('registration');
     });
 

--- a/routes/store.php
+++ b/routes/store.php
@@ -119,7 +119,8 @@ Route::middleware('auth:store')->group(function (): void {
             ->name('store.registration.vouchers.post')
             ->whereNumber('registration');
 
-        Route::post('/registrations/{registration}/vouchers/payment-requests',
+        Route::post(
+            '/registrations/{registration}/vouchers/payment-requests',
             [BundleController::class, 'requestPayment']
         )
             ->name('store.registration.vouchers.payment-requests.post')

--- a/routes/store.php
+++ b/routes/store.php
@@ -89,7 +89,7 @@ Route::middleware('auth:store')->group(function (): void {
             ->name('store.registration.print')
             ->whereNumber('registration');
 
-        Route::put('/registrations/{registration}/vouchers', [BundleController::class, 'update'])
+        Route::put('/registrations/{registration}/vouchers', [BundleController::class, 'pickup'])
             ->name('store.registration.vouchers.put')
             ->whereNumber('registration');
 

--- a/routes/store.php
+++ b/routes/store.php
@@ -119,7 +119,7 @@ Route::middleware('auth:store')->group(function (): void {
             ->name('store.registration.vouchers.post')
             ->whereNumber('registration');
 
-        Route::post(
+        Route::put(
             '/registrations/{registration}/vouchers/transitions/collection',
             [BundleController::class, 'collectBundle']
         )

--- a/tests/Unit/Controllers/Store/BundleControllerTest.php
+++ b/tests/Unit/Controllers/Store/BundleControllerTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Unit\Controllers\Store;
 
-use App\Bundle;
 use App\Centre;
 use App\CentreUser;
 use App\Family;
@@ -13,7 +12,6 @@ use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Session;
-use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\StoreTestCase;
 
 class BundleControllerTest extends StoreTestCase
@@ -56,182 +54,6 @@ class BundleControllerTest extends StoreTestCase
         $this->programme = Auth::user()->centre->sponsor->programme;
 
         Auth::logout();
-    }
-
-    // -------------------------------------------------------------------------
-    // Append-vouchers validation — data provider
-    // -------------------------------------------------------------------------
-
-    /**
-     * @return array<string, array{array<string,string>, string, string}>
-     *
-     * Config placeholders: config() is unavailable in static providers (they are constructed
-     * before the Laravel application boots). Two placeholders are used instead and resolved
-     * inside the test method once the container is live:
-     *   :max:          → config('arc.bundle_max_voucher_append')
-     *   :max_plus_one: → config('arc.bundle_max_voucher_append') + 1
-     */
-    public static function appendVoucherValidationCases(): array
-    {
-        return [
-            // --- start field (voucher-quantity absent branch) ---
-            'start: absent with no data submitted' => [
-                [],
-                'start',
-                'The start field is required when voucher-quantity is not present.',
-            ],
-            'start: absent when only end supplied' => [
-                ['end' => 'tst10001'],
-                'start',
-                'The start field is required when voucher-quantity is not present.',
-            ],
-            'start: empty string stripped by prepareForValidation' => [
-                ['start' => '', 'end' => 'tst10001'],
-                'start',
-                'The start field is required when voucher-quantity is not present.',
-            ],
-            'start: value not found in vouchers table' => [
-                ['start' => 'invalidVoucher', 'end' => 'tst10001'],
-                'start',
-                'The selected start is invalid.',
-            ],
-
-            // --- end field ---
-            'end: value not found in vouchers table' => [
-                ['start' => 'tst09999', 'end' => 'invalidCode'],
-                'end',
-                'The selected end is invalid.',
-            ],
-            'end: different sponsor prefix to start' => [
-                ['start' => 'tst09999', 'end' => 'txt10000'],
-                'end',
-                'The end field must be the same sponsor as the start field.',
-            ],
-            'end: lower sequence number than start' => [
-                ['start' => 'tst10001', 'end' => 'tst09999'],
-                'end',
-                'The end field must be greater than the start field.',
-            ],
-
-            // --- voucher-quantity field (early-return branch) ---
-            'voucher-quantity: zero is below the allowed minimum of 1' => [
-                ['voucher-quantity' => '0'],
-                'voucher-quantity',
-                'The voucher-quantity must be between 1 and :max:.',
-            ],
-            'voucher-quantity: negative value is below the allowed minimum of 1' => [
-                ['voucher-quantity' => '-1'],
-                'voucher-quantity',
-                'The voucher-quantity must be between 1 and :max:.',
-            ],
-            'voucher-quantity: exceeds the configured maximum' => [
-                ['voucher-quantity' => ':max_plus_one:'],
-                'voucher-quantity',
-                'The voucher-quantity must be between 1 and :max:.',
-            ],
-            'voucher-quantity: required when start also absent' => [
-                [],
-                'voucher-quantity',
-                'The voucher-quantity field is required when start is not present.',
-            ],
-        ];
-    }
-
-    #[DataProvider('appendVoucherValidationCases')]
-    public function testICannotSubmitInvalidValuesToAppendVouchers(
-        array $data,
-        string $field,
-        string $expectedMessage,
-    ): void {
-        $max = (string)config('arc.bundle_max_voucher_append');
-
-        // Resolve placeholders that cannot be evaluated inside a static data provider.
-        $data = array_map(static function (string $v) use ($max) {
-            return str_replace(':max_plus_one:', (string)((int)$max + 1), $v);
-        }, $data);
-        $expectedMessage = str_replace(':max:', $max, $expectedMessage);
-
-        $route = route('store.registration.voucher-manager', ['registration' => $this->registration->id]);
-        $postRoute = route('store.registration.vouchers.post', ['registration' => $this->registration->id]);
-
-        $this->actingAs($this->centreUser, 'store')
-            ->visit($route)
-            ->post($postRoute, $data);
-
-        $errors = session('errors')->get($field);
-
-        $this->assertNotEmpty($errors, "Expected validation errors for field '$field'");
-        $this->assertContains($expectedMessage, $errors);
-
-        $this->followRedirects()
-            ->seePageIs($route)
-            ->assertResponseStatus(200);
-    }
-
-    // -------------------------------------------------------------------------
-    // Disbursement validation — data provider
-    // -------------------------------------------------------------------------
-
-    /**
-     * @return array<string, array{array<string,string>, string, string}>
-     */
-    public static function disburseValidationCases(): array
-    {
-        return [
-            'collected_by missing' => [
-                ['collected_at' => '1', 'collected_on' => '2018-07-21'],
-                'collected_by',
-                'The collected by field is required when collected at / collected on is present.',
-            ],
-            'collected_at missing' => [
-                ['collected_by' => '1', 'collected_on' => '2018-07-21'],
-                'collected_at',
-                'The collected at field is required when collected on / collected by is present.',
-            ],
-            'collected_on missing' => [
-                ['collected_at' => '1', 'collected_by' => '1'],
-                'collected_on',
-                'The collected on field is required when collected at / collected by is present.',
-            ],
-            'collected_on wrong date format' => [
-                ['collected_at' => '1', 'collected_on' => 'invalid', 'collected_by' => '1'],
-                'collected_on',
-                'The collected on does not match the format Y-m-d.',
-            ],
-            'collected_at centre does not exist' => [
-                ['collected_at' => '9999', 'collected_on' => '2018-07-21', 'collected_by' => '1'],
-                'collected_at',
-                'The selected collected at is invalid.',
-            ],
-            'collected_by carer does not exist' => [
-                ['collected_at' => '1', 'collected_on' => '2018-07-21', 'collected_by' => '9999'],
-                'collected_by',
-                'The selected collected by is invalid.',
-            ],
-        ];
-    }
-
-    #[DataProvider('disburseValidationCases')]
-    public function testIMustDisburseWithAllRelevantFields(
-        array $data,
-        string $field,
-        string $expectedMessage,
-    ): void {
-        $route = route('store.registration.voucher-manager', ['registration' => $this->registration->id]);
-        $putRoute = route('store.registration.vouchers.put', ['registration' => $this->registration->id]);
-
-        $this->actingAs($this->centreUser, 'store')
-            ->visit($route)
-            ->put($putRoute, $data);
-
-        $errors = session('errors')->get($field);
-
-        $this->assertNotEmpty($errors, "Expected validation errors for field '$field'");
-        $this->assertContains($expectedMessage, $errors);
-
-        $this->followRedirects()
-            ->seePageIs($route)
-            ->assertResponseStatus(200);
     }
 
     // -------------------------------------------------------------------------
@@ -402,7 +224,7 @@ class BundleControllerTest extends StoreTestCase
 
         // Insert a space at a random position in the voucher code.
         $voucherCode = $this->testCodes[0];
-        $voucherCode = substr_replace($voucherCode, ' ', random_int(0, strlen($voucherCode)), 0);
+        $voucherCode = substr_replace($voucherCode, ' ', rand(0, strlen($voucherCode)), 0);
 
         $this->actingAs($this->centreUser, 'store')
             ->post($postRoute, ['start' => $voucherCode]);
@@ -506,7 +328,6 @@ class BundleControllerTest extends StoreTestCase
 
     public function testICanDeleteANamedVoucher(): void
     {
-        /** @var Bundle $currentBundle */
         $currentBundle = $this->registration->currentBundle();
         $bundledCodes = ['TST0123455', 'TST0123456', 'TST0123457'];
 
@@ -520,7 +341,6 @@ class BundleControllerTest extends StoreTestCase
 
         $this->assertSame(count($bundledCodes), $currentBundle->vouchers()->count());
 
-        /** @var Voucher $target */
         $target = $currentBundle->vouchers()->first();
         $deleteRoute = route('store.registration.voucher.delete', [
             'registration' => $this->registration->id,

--- a/tests/Unit/Controllers/Store/BundleControllerTest.php
+++ b/tests/Unit/Controllers/Store/BundleControllerTest.php
@@ -2,11 +2,13 @@
 
 namespace Tests\Unit\Controllers\Store;
 
+use App\Bundle;
 use App\Centre;
 use App\CentreUser;
 use App\Family;
 use App\Registration;
 use App\Sponsor;
+use App\Trader;
 use App\Voucher;
 use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -57,19 +59,98 @@ class BundleControllerTest extends StoreTestCase
     }
 
     // -------------------------------------------------------------------------
-    // Adding vouchers to a bundle
+    // Private test helpers
     // -------------------------------------------------------------------------
+
+    /**
+     * Create a dispatched voucher and attach it directly to the given bundle,
+     * bypassing alterVouchers so we can reach states that the normal flow would reject.
+     */
+    private function attachDispatchedVoucherToBundle(string $code, Bundle $bundle): Voucher
+    {
+        $voucher = factory(Voucher::class)->state('printed')->create(['code' => $code]);
+        $voucher->applyTransition('dispatch');
+        $voucher->bundle()->associate($bundle)->save();
+
+        return $voucher;
+    }
+
+    /**
+     * Valid disbursal payload using fixtures from setUp.
+     */
+    private function defaultDisbursalData(): array
+    {
+        return [
+            'collected_at' => $this->centre->id,
+            'collected_on' => Carbon::now()->startOfWeek()->format('Y-m-d'),
+            'collected_by' => $this->registration->family->carers->first()->id,
+        ];
+    }
+
+    /**
+     * Named route to the voucher manager for the primary test registration.
+     */
+    private function managerRoute(?Registration $registration = null): string
+    {
+        return route('store.registration.voucher-manager', [
+            'registration' => ($registration ?? $this->registration)->id,
+        ]);
+    }
+
+    /**
+     * Search session error messages for one matching the given regular expression.
+     * Handles both plain strings and HtmlString instances (serialised with an 'html' key).
+     *
+     * @param array<int, string|array<string, string>> $errorMessages
+     */
+    private function hasMatchingErrorMessage(array $errorMessages, string $regex): bool
+    {
+        foreach ($errorMessages as $error) {
+            $string = is_array($error) && array_key_exists('html', $error)
+                ? $error['html']
+                : (string)$error;
+
+            if (preg_match($regex, $string)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // =========================================================================
+    // create() — voucher manager view
+    // =========================================================================
+
+    public function testCreateRendersTheVoucherManagerView(): void
+    {
+        $this->actingAs($this->centreUser, 'store')
+            ->visit($this->managerRoute())
+            ->assertResponseStatus(200)
+            ->seePageIs($this->managerRoute());
+    }
+
+    public function testCreateViewContainsRegistrationAndCarerData(): void
+    {
+        $this->actingAs($this->centreUser, 'store')
+            ->visit($this->managerRoute())
+            ->assertResponseStatus(200)
+            ->see($this->centreUser->centre->name);
+    }
+
+    // =========================================================================
+    // addVouchersToCurrentBundle() — single code / range
+    // =========================================================================
 
     public function testICanAddSingleVouchers(): void
     {
-        $route = route('store.registration.voucher-manager', ['registration' => $this->registration->id]);
         $postRoute = route('store.registration.vouchers.post', ['registration' => $this->registration->id]);
 
         $this->actingAs($this->centreUser, 'store')
             ->post($postRoute, ['start' => $this->testCodes[0]]);
 
         $this->followRedirects()
-            ->seePageIs($route)
+            ->seePageIs($this->managerRoute())
             ->assertResponseStatus(200);
 
         $this->assertSame(1, $this->registration->currentBundle()->vouchers()->count());
@@ -77,7 +158,6 @@ class BundleControllerTest extends StoreTestCase
 
     public function testICanAddManyVouchers(): void
     {
-        $route = route('store.registration.voucher-manager', ['registration' => $this->registration->id]);
         $postRoute = route('store.registration.vouchers.post', ['registration' => $this->registration->id]);
 
         $this->actingAs($this->centreUser, 'store')
@@ -87,17 +167,38 @@ class BundleControllerTest extends StoreTestCase
             ]);
 
         $this->followRedirects()
-            ->seePageIs($route)
+            ->seePageIs($this->managerRoute())
             ->assertResponseStatus(200);
 
         $this->assertSame(count($this->testCodes), $this->registration->currentBundle()->vouchers()->count());
     }
 
-    public function testICannotAddTooManyVouchersToABundle(): void
+    public function testAddingVouchersRedirectsToManagerRouteOnSuccess(): void
     {
-        $route = route('store.registration.voucher-manager', ['registration' => $this->registration->id]);
         $postRoute = route('store.registration.vouchers.post', ['registration' => $this->registration->id]);
 
+        $this->actingAs($this->centreUser, 'store')
+            ->post($postRoute, ['start' => $this->testCodes[0]]);
+
+        $this->followRedirects()
+            ->seePageIs($this->managerRoute())
+            ->assertResponseStatus(200);
+    }
+
+    public function testAddingVouchersFlashesGenericSuccessMessage(): void
+    {
+        $postRoute = route('store.registration.vouchers.post', ['registration' => $this->registration->id]);
+
+        $response = $this->actingAs($this->centreUser, 'store')
+            ->post($postRoute, ['start' => $this->testCodes[0]]);
+
+        $response->seeInSession('message');
+        $this->assertSame('Vouchers updated', Session::get('message'));
+    }
+
+    public function testICannotAddTooManyVouchersToABundle(): void
+    {
+        $postRoute = route('store.registration.vouchers.post', ['registration' => $this->registration->id]);
         $overMaxAdd = config('arc.bundle_max_voucher_append') + 1;
         $startCode = 'BIG00001';
         $endCode = 'BIG' . str_pad((string)$overMaxAdd, 5, '0', STR_PAD_LEFT);
@@ -122,40 +223,117 @@ class BundleControllerTest extends StoreTestCase
         ));
 
         $this->followRedirects()
-            ->seePageIs($route)
+            ->seePageIs($this->managerRoute())
             ->assertResponseStatus(200);
 
         $this->assertSame(0, $this->registration->currentBundle()->vouchers()->count());
     }
 
+    public function testAddingARangeWithMissingIntermediateCodesFlashesCodesError(): void
+    {
+        // StoreAppendBundleRequest validates that `start` and `end` exist:vouchers,code,
+        // so we cannot trigger the controller's 'codes' error with a non-existent single
+        // code — validation rejects it before the controller runs.
+        //
+        // The correct path: submit a range whose endpoints both exist in the DB but whose
+        // interior contains codes that were never created.  generateCodeRange produces
+        // ['GAP00001', 'GAP00002', 'GAP00003']; addVouchers finds only the two endpoints;
+        // alterVouchers reports GAP00002 under the 'codes' error key.
+        $postRoute = route('store.registration.vouchers.post', ['registration' => $this->registration->id]);
+
+        Auth::login($this->centreUser);
+        $start = factory(Voucher::class)->state('printed')->create(['code' => 'GAP00001']);
+        $start->applyTransition('dispatch');
+        $end = factory(Voucher::class)->state('printed')->create(['code' => 'GAP00003']);
+        $end->applyTransition('dispatch');
+        // GAP00002 is deliberately never created.
+        Auth::logout();
+
+        $response = $this->actingAs($this->centreUser, 'store')
+            ->post($postRoute, ['start' => 'GAP00001', 'end' => 'GAP00003']);
+
+        $response->seeInSession('error_messages');
+        $this->assertTrue($this->hasMatchingErrorMessage(
+            Session::get('error_messages'),
+            '/These codes are invalid: GAP00002/',
+        ));
+    }
+
+    public function testAddingAnAlreadyDisbursedVoucherFlashesDisbursedError(): void
+    {
+        // Disburse a voucher on a second registration so its bundle has disbursed_at set.
+        $otherReg = factory(Registration::class)->create(['centre_id' => $this->centre->id]);
+        $otherBundle = $otherReg->currentBundle();
+
+        Auth::login($this->centreUser);
+        $this->attachDispatchedVoucherToBundle('DSB00001', $otherBundle);
+        Auth::logout();
+
+        $otherBundle->disbursed_at = Carbon::now();
+        $otherBundle->collectingCarer()->associate($otherReg->family->carers->first());
+        $otherBundle->disbursingCentre()->associate($this->centre);
+        $otherBundle->disbursingUser()->associate($this->centreUser);
+        $otherBundle->save();
+
+        $postRoute = route('store.registration.vouchers.post', ['registration' => $this->registration->id]);
+
+        $response = $this->actingAs($this->centreUser, 'store')
+            ->post($postRoute, ['start' => 'DSB00001']);
+
+        $response->seeInSession('error_messages');
+        $this->assertTrue($this->hasMatchingErrorMessage(
+            Session::get('error_messages'),
+            '/These vouchers have been given out: DSB00001/',
+        ));
+        $this->assertSame(0, $this->registration->currentBundle()->vouchers()->count());
+    }
+
+    public function testAddingAVoucherInAUsedStateFlashesUsedError(): void
+    {
+        $postRoute = route('store.registration.vouchers.post', ['registration' => $this->registration->id]);
+
+        Auth::login($this->centreUser);
+        $voucher = factory(Voucher::class)->state('printed')->create(['code' => 'USED00001']);
+        $voucher->applyTransition('dispatch');
+        $trader = factory(Trader::class)->create();
+        $voucher->trader_id = $trader->id;
+        $voucher->applyTransition('collect');   // now in 'collected' — cannot be re-collected
+        Auth::logout();
+
+        $response = $this->actingAs($this->centreUser, 'store')
+            ->post($postRoute, ['start' => 'USED00001']);
+
+        $response->seeInSession('error_messages');
+        $this->assertTrue($this->hasMatchingErrorMessage(
+            Session::get('error_messages'),
+            '/These vouchers have already been used: USED00001/',
+        ));
+        $this->assertSame(0, $this->registration->currentBundle()->vouchers()->count());
+    }
+
     public function testICannotAddAVoucherAllocatedInACentreIHaveAccessTo(): void
     {
-        $route = route('store.registration.voucher-manager', ['registration' => $this->registration->id]);
         $postRoute = route('store.registration.vouchers.post', ['registration' => $this->registration->id]);
 
         // Allocate the first test voucher to the primary registration.
         $this->actingAs($this->centreUser, 'store')
             ->post($postRoute, ['start' => $this->testCodes[0]]);
 
-        // Create a second registration in the same centre.
+        // Create a second registration in the same centre and try to claim the same voucher.
         $registrationTwo = factory(Registration::class)->create(['centre_id' => $this->centre->id]);
-
-        $route2 = route('store.registration.voucher-manager', ['registration' => $registrationTwo->id]);
         $postRoute2 = route('store.registration.vouchers.post', ['registration' => $registrationTwo->id]);
 
-        // Attempt to add the already-allocated voucher to the second bundle.
         $response = $this->actingAs($this->centreUser, 'store')
-            ->visit($route2)
+            ->visit($this->managerRoute($registrationTwo))
             ->post($postRoute2, ['start' => $this->testCodes[0]]);
 
         $this->assertSame(0, $registrationTwo->currentBundle()->vouchers()->count());
-
         $response->seeInSession('error_messages');
 
         $entity = Family::getAlias($this->programme);
         $expectedPattern = '~These vouchers are currently allocated to a different ' . $entity
             . '. Click on the voucher number to view the other ' . $entity
-            . '\'s record: <a href="' . $route . '">' . $this->testCodes[0] . '</a>~';
+            . '\'s record: <a href="' . $this->managerRoute() . '">' . $this->testCodes[0] . '</a>~';
 
         $this->assertTrue($this->hasMatchingErrorMessage(Session::get('error_messages'), $expectedPattern));
 
@@ -163,7 +341,7 @@ class BundleControllerTest extends StoreTestCase
             ->seeInElement(
                 'div[class="alert-message error"]',
                 'Click on the voucher number to view the other ' . $entity
-                . '\'s record: <a href="' . $route . '">' . $this->testCodes[0] . '</a>',
+                . '\'s record: <a href="' . $this->managerRoute() . '">' . $this->testCodes[0] . '</a>',
             );
     }
 
@@ -187,16 +365,13 @@ class BundleControllerTest extends StoreTestCase
         $centreUser2->centres()->attach($centre2->id, ['homeCentre' => true]);
 
         $registrationTwo = factory(Registration::class)->create(['centre_id' => $centre2->id]);
-
-        $route2 = route('store.registration.voucher-manager', ['registration' => $registrationTwo->id]);
         $postRoute2 = route('store.registration.vouchers.post', ['registration' => $registrationTwo->id]);
 
         $response = $this->actingAs($centreUser2, 'store')
-            ->visit($route2)
+            ->visit($this->managerRoute($registrationTwo))
             ->post($postRoute2, ['start' => $this->testCodes[1]]);
 
         $this->assertSame(0, $registrationTwo->currentBundle()->vouchers()->count());
-
         $response->seeInSession('error_messages');
 
         $entity = Family::getAlias($this->programme);
@@ -213,16 +388,13 @@ class BundleControllerTest extends StoreTestCase
             );
     }
 
-    // -------------------------------------------------------------------------
-    // Input cleaning
-    // -------------------------------------------------------------------------
+    // =========================================================================
+    // addVouchersToCurrentBundle() — input cleaning
+    // =========================================================================
 
     public function testItCanAcceptAndCleanVouchersWithSpacesIn(): void
     {
-        $route = route('store.registration.voucher-manager', ['registration' => $this->registration->id]);
         $postRoute = route('store.registration.vouchers.post', ['registration' => $this->registration->id]);
-
-        // Insert a space at a random position in the voucher code.
         $voucherCode = $this->testCodes[0];
         $voucherCode = substr_replace($voucherCode, ' ', rand(0, strlen($voucherCode)), 0);
 
@@ -230,7 +402,7 @@ class BundleControllerTest extends StoreTestCase
             ->post($postRoute, ['start' => $voucherCode]);
 
         $this->followRedirects()
-            ->seePageIs($route)
+            ->seePageIs($this->managerRoute())
             ->assertResponseStatus(200);
 
         $this->assertSame(1, $this->registration->currentBundle()->vouchers()->count());
@@ -255,20 +427,18 @@ class BundleControllerTest extends StoreTestCase
         $this->assertSame($this->testCodes[1], $lastVoucher->code);
     }
 
-    // -------------------------------------------------------------------------
-    // Delete operations
-    // -------------------------------------------------------------------------
+    // =========================================================================
+    // removeAllVouchersFromCurrentBundle()
+    // =========================================================================
 
-    public function testICanDeleteTheCurrentBundle(): void
+    public function testICanRemoveAllVouchersFromTheCurrentBundle(): void
     {
         $currentBundle = $this->registration->currentBundle();
         $deleteCodes = ['TST0123455', 'TST0123456', 'TST0123457'];
 
         Auth::login($this->centreUser);
         foreach ($deleteCodes as $code) {
-            $voucher = factory(Voucher::class)->state('printed')->create(['code' => $code]);
-            $voucher->applyTransition('dispatch');
-            $voucher->bundle()->associate($currentBundle)->save();
+            $this->attachDispatchedVoucherToBundle($code, $currentBundle);
         }
         Auth::logout();
 
@@ -282,12 +452,36 @@ class BundleControllerTest extends StoreTestCase
         $currentBundle->refresh();
         $this->assertSame(0, $currentBundle->vouchers()->count());
 
-        // Every previously-bundled voucher should have a null bundle_id.
         Voucher::whereIn('code', $deleteCodes)
-            ->each(function (Voucher $v) {
-                return $this->assertNull($v->bundle_id);
-            });
+            ->each(fn (Voucher $v) => $this->assertNull($v->bundle_id));
     }
+
+    public function testICanDeleteTheCurrentBundle(): void
+    {
+        // Alias preserved for backwards compatibility — delegates to the renamed test body.
+        $this->testICanRemoveAllVouchersFromTheCurrentBundle();
+    }
+
+    public function testRemovingAllVouchersFlashesGenericSuccessMessage(): void
+    {
+        $currentBundle = $this->registration->currentBundle();
+
+        Auth::login($this->centreUser);
+        $this->attachDispatchedVoucherToBundle('REM00001', $currentBundle);
+        Auth::logout();
+
+        $deleteRoute = route('store.registration.vouchers.delete', ['registration' => $this->registration->id]);
+
+        $response = $this->actingAs($this->centreUser, 'store')
+            ->delete($deleteRoute);
+
+        $response->seeInSession('message');
+        $this->assertSame('Vouchers updated', Session::get('message'));
+    }
+
+    // =========================================================================
+    // removeVoucherFromCurrentBundle()
+    // =========================================================================
 
     public function testICanDeleteANamedVoucher(): void
     {
@@ -296,9 +490,7 @@ class BundleControllerTest extends StoreTestCase
 
         Auth::login($this->centreUser);
         foreach ($bundledCodes as $code) {
-            $voucher = factory(Voucher::class)->state('printed')->create(['code' => $code]);
-            $voucher->applyTransition('dispatch');
-            $voucher->bundle()->associate($currentBundle)->save();
+            $this->attachDispatchedVoucherToBundle($code, $currentBundle);
         }
         Auth::logout();
 
@@ -321,24 +513,133 @@ class BundleControllerTest extends StoreTestCase
         $this->assertSame('dispatched', $target->currentstate);
     }
 
-    // -------------------------------------------------------------------------
-    // Disbursement
-    // -------------------------------------------------------------------------
+    public function testRemovingANamedVoucherFlashesGenericSuccessMessage(): void
+    {
+        $currentBundle = $this->registration->currentBundle();
+
+        Auth::login($this->centreUser);
+        $voucher = $this->attachDispatchedVoucherToBundle('REM00002', $currentBundle);
+        Auth::logout();
+
+        $deleteRoute = route('store.registration.voucher.delete', [
+            'registration' => $this->registration->id,
+            'voucher' => $voucher->id,
+        ]);
+
+        $response = $this->actingAs($this->centreUser, 'store')
+            ->delete($deleteRoute);
+
+        $response->seeInSession('message');
+        $this->assertSame('Vouchers updated', Session::get('message'));
+    }
+
+    public function testICannotRemoveAVoucherThatBelongsToADifferentBundle(): void
+    {
+        // Attach a voucher to a *different* registration's bundle.
+        $otherReg = factory(Registration::class)->create(['centre_id' => $this->centre->id]);
+        $otherBundle = $otherReg->currentBundle();
+
+        Auth::login($this->centreUser);
+        $voucher = $this->attachDispatchedVoucherToBundle('OTH00001', $otherBundle);
+        Auth::logout();
+
+        // Attempt to remove that voucher through *this* registration's route.
+        $deleteRoute = route('store.registration.voucher.delete', [
+            'registration' => $this->registration->id,
+            'voucher' => $voucher->id,
+        ]);
+
+        $response = $this->actingAs($this->centreUser, 'store')
+            ->delete($deleteRoute);
+
+        $response->seeInSession('error_messages');
+        $this->assertTrue($this->hasMatchingErrorMessage(
+            Session::get('error_messages'),
+            '/These vouchers do not belong to this bundle: OTH00001/',
+        ));
+
+        // Voucher must still belong to the other bundle.
+        $voucher->refresh();
+        $this->assertSame($otherBundle->id, $voucher->bundle_id);
+    }
+
+    // =========================================================================
+    // pickup() — disbursal without state-machine transition
+    // =========================================================================
+
+    public function testICanDisburseABundleViaPickup(): void
+    {
+        $currentBundle = $this->registration->currentBundle();
+
+        Auth::login($this->centreUser);
+        $this->attachDispatchedVoucherToBundle('PKP00001', $currentBundle);
+        Auth::logout();
+
+        $putRoute = route('store.registration.vouchers.put', ['registration' => $this->registration->id]);
+
+        $this->actingAs($this->centreUser, 'store')
+            ->put($putRoute, $this->defaultDisbursalData());
+
+        $this->followRedirects()
+            ->seePageIs(route('store.registration.index'))
+            ->assertResponseStatus(200);
+
+        $currentBundle->refresh();
+        $this->assertNotNull($currentBundle->disbursed_at);
+        $this->assertSame(
+            Carbon::now()->startOfWeek()->toDateString(),
+            $currentBundle->disbursed_at->toDateString(),
+        );
+    }
+
+    public function testSuccessfulPickupRedirectsToRegistrationIndex(): void
+    {
+        $currentBundle = $this->registration->currentBundle();
+
+        Auth::login($this->centreUser);
+        $this->attachDispatchedVoucherToBundle('PKP00002', $currentBundle);
+        Auth::logout();
+
+        $putRoute = route('store.registration.vouchers.put', ['registration' => $this->registration->id]);
+
+        $this->actingAs($this->centreUser, 'store')
+            ->put($putRoute, $this->defaultDisbursalData());
+
+        $this->followRedirects()
+            ->seePageIs(route('store.registration.index'))
+            ->assertResponseStatus(200);
+    }
+
+    public function testSuccessfulPickupFlashesMessageNamingCarerAndVoucherCount(): void
+    {
+        $currentBundle = $this->registration->currentBundle();
+
+        Auth::login($this->centreUser);
+        $this->attachDispatchedVoucherToBundle('PKP00003', $currentBundle);
+        Auth::logout();
+
+        $putRoute = route('store.registration.vouchers.put', ['registration' => $this->registration->id]);
+
+        $response = $this->actingAs($this->centreUser, 'store')
+            ->put($putRoute, $this->defaultDisbursalData());
+
+        $response->seeInSession('message');
+
+        $carer = $this->registration->family->carers->first();
+        $message = Session::get('message');
+
+        $this->assertStringContainsString('1', $message);
+        $this->assertStringContainsString('voucher', $message);
+        $this->assertStringContainsString($carer->name, $message);
+    }
 
     public function testICannotDisburseAnEmptyBundle(): void
     {
-        $route = route('store.registration.voucher-manager', ['registration' => $this->registration->id]);
         $putRoute = route('store.registration.vouchers.put', ['registration' => $this->registration->id]);
 
-        $data = [
-            'collected_at' => $this->centre->id,
-            'collected_on' => Carbon::now()->startOfWeek()->format('Y-m-d'),
-            'collected_by' => $this->registration->family->carers->first()->id,
-        ];
-
         $response = $this->actingAs($this->centreUser, 'store')
-            ->visit($route)
-            ->put($putRoute, $data);
+            ->visit($this->managerRoute())
+            ->put($putRoute, $this->defaultDisbursalData());
 
         $response->seeInSession('error_messages');
         $this->assertTrue($this->hasMatchingErrorMessage(
@@ -347,32 +648,182 @@ class BundleControllerTest extends StoreTestCase
         ));
 
         $this->followRedirects()
-            ->seePageIs($route)
+            ->seePageIs($this->managerRoute())
             ->assertResponseStatus(200);
     }
 
-    // -------------------------------------------------------------------------
-    // Helpers
-    // -------------------------------------------------------------------------
-
-    /**
-     * Search an array of session error messages for one matching the given regular expression.
-     * Handles both plain strings and HtmlString-derived arrays with a 'html' key.
-     *
-     * @param array<int, string|array<string, string>> $errorMessages
-     */
-    private function hasMatchingErrorMessage(array $errorMessages, string $regex): bool
+    public function testEmptyBundleDisbursalRedirectsBackToManager(): void
     {
-        foreach ($errorMessages as $error) {
-            $string = is_array($error) && array_key_exists('html', $error)
-                ? $error['html']
-                : (string)$error;
+        $putRoute = route('store.registration.vouchers.put', ['registration' => $this->registration->id]);
 
-            if (preg_match($regex, $string)) {
-                return true;
-            }
+        $this->actingAs($this->centreUser, 'store')
+            ->visit($this->managerRoute())
+            ->put($putRoute, $this->defaultDisbursalData());
+
+        $this->followRedirects()
+            ->seePageIs($this->managerRoute())
+            ->assertResponseStatus(200);
+    }
+
+    // =========================================================================
+    // collectBundle() — disbursal + state-machine transition
+    // =========================================================================
+
+    public function testICanCollectABundleAndTransitionItsVouchers(): void
+    {
+        $currentBundle = $this->registration->currentBundle();
+        $trader = factory(Trader::class)->create();
+
+        // Associate already-dispatched test vouchers with the bundle.
+        // Set delivery_id so handleCollect's undelivered-check is bypassed.
+        Auth::login($this->centreUser);
+        foreach ($this->testCodes as $code) {
+            $voucher = Voucher::where('code', $code)->firstOrFail();
+            $voucher->delivery_id = 1; // prevents the undelivered branch in handleCollect
+            $voucher->bundle()->associate($currentBundle)->save();
         }
+        Auth::logout();
 
-        return false;
+        $collectRoute = route(
+            'store.registration.vouchers.transitions.collect',
+            ['registration' => $this->registration->id]
+        );
+
+        $this->actingAs($this->centreUser, 'store')
+            ->post($collectRoute, array_merge(
+                $this->defaultDisbursalData(),
+                ['trader_id' => $trader->id],
+            ));
+
+        $this->followRedirects()
+            ->seePageIs(route('store.registration.index'))
+            ->assertResponseStatus(200);
+
+        $currentBundle->refresh();
+        $this->assertNotNull($currentBundle->disbursed_at);
+
+        foreach ($this->testCodes as $code) {
+            $this->assertSame('recorded', Voucher::where('code', $code)->first()->currentstate);
+        }
+    }
+
+    public function testCollectBundleRedirectsToRegistrationIndexOnSuccess(): void
+    {
+        $currentBundle = $this->registration->currentBundle();
+        $trader = factory(Trader::class)->create();
+
+        Auth::login($this->centreUser);
+        $voucher = Voucher::where('code', $this->testCodes[0])->firstOrFail();
+        $voucher->delivery_id = 1;
+        $voucher->bundle()->associate($currentBundle)->save();
+        Auth::logout();
+
+        $collectRoute = route(
+            'store.registration.vouchers.transitions.collect',
+            ['registration' => $this->registration->id]
+        );
+
+        $this->actingAs($this->centreUser, 'store')
+            ->post($collectRoute, array_merge(
+                $this->defaultDisbursalData(),
+                ['trader_id' => $trader->id],
+            ));
+
+        $this->followRedirects()
+            ->seePageIs(route('store.registration.index'))
+            ->assertResponseStatus(200);
+    }
+
+    public function testCollectBundleRollsBackWhenBundleIsEmpty(): void
+    {
+        $collectRoute = route(
+            'store.registration.vouchers.transitions.collect',
+            ['registration' => $this->registration->id]
+        );
+        $trader = factory(Trader::class)->create();
+
+        $response = $this->actingAs($this->centreUser, 'store')
+            ->post($collectRoute, array_merge(
+                $this->defaultDisbursalData(),
+                ['trader_id' => $trader->id],
+            ));
+
+        $response->seeInSession('error_messages');
+        $this->assertTrue($this->hasMatchingErrorMessage(
+            Session::get('error_messages'),
+            '/Action denied on empty bundle/',
+        ));
+
+        $this->followRedirects()
+            ->seePageIs($this->managerRoute())
+            ->assertResponseStatus(200);
+    }
+
+    public function testCollectBundleRollsBackDisbursalWhenTransitionFails(): void
+    {
+        // Push first_delivery_date into the future so handleCollect's undelivered guard
+        // evaluates false (future_date <= now is false) and the already-collected voucher
+        // reaches the actual transition attempt rather than the undelivered skip-path.
+        config(['arc.first_delivery_date' => Carbon::now()->addYear()->toDateString()]);
+
+        $currentBundle = $this->registration->currentBundle();
+        $trader = factory(Trader::class)->create();
+
+        Auth::login($this->centreUser);
+        $voucher = factory(Voucher::class)->state('printed')->create(['code' => 'COLT0001']);
+        $voucher->applyTransition('dispatch');
+        $voucher->trader_id = $trader->id;
+        $voucher->applyTransition('collect');
+        $voucher->bundle()->associate($currentBundle)->save();
+        Auth::logout();
+
+        $collectRoute = route(
+            'store.registration.vouchers.transitions.collect',
+            ['registration' => $this->registration->id]
+        );
+
+        $this->actingAs($this->centreUser, 'store')
+            ->post($collectRoute, array_merge(
+                $this->defaultDisbursalData(),
+                ['trader_id' => $trader->id],
+            ));
+
+        // Disbursal must have been rolled back because the transition was denied.
+        $currentBundle->refresh();
+        $this->assertNull($currentBundle->disbursed_at);
+    }
+
+    public function testCollectBundleFlashesTransitionErrorCodesOnFailure(): void
+    {
+        // Same guard bypass as testCollectBundleRollsBackDisbursalWhenTransitionFails.
+        config(['arc.first_delivery_date' => Carbon::now()->addYear()->toDateString()]);
+
+        $currentBundle = $this->registration->currentBundle();
+        $trader = factory(Trader::class)->create();
+
+        Auth::login($this->centreUser);
+        $voucher = factory(Voucher::class)->state('printed')->create(['code' => 'COLT0002']);
+        $voucher->applyTransition('dispatch');
+        $voucher->trader_id = $trader->id;
+        $voucher->applyTransition('collect');
+        $voucher->bundle()->associate($currentBundle)->save();
+        Auth::logout();
+
+        $collectRoute = route(
+            'store.registration.vouchers.transitions.collect',
+            ['registration' => $this->registration->id]
+        );
+
+        $response = $this->actingAs($this->centreUser, 'store')
+            ->post($collectRoute, array_merge(
+                $this->defaultDisbursalData(),
+                ['trader_id' => $trader->id],
+            ));
+
+        $response->seeInSession('error_messages');
+        $this->assertTrue($this->hasMatchingErrorMessage(
+            Session::get('error_messages'),
+            '/Voucher state change problem with:/',
+        ));
     }
 }

--- a/tests/Unit/Controllers/Store/BundleControllerTest.php
+++ b/tests/Unit/Controllers/Store/BundleControllerTest.php
@@ -99,18 +99,13 @@ class BundleControllerTest extends StoreTestCase
 
     /**
      * Search session error messages for one matching the given regular expression.
-     * Handles both plain strings and HtmlString instances (serialised with an 'html' key).
      *
-     * @param array<int, string|array<string, string>> $errorMessages
+     * @param array<int, string|HtmlString> $errorMessages
      */
     private function hasMatchingErrorMessage(array $errorMessages, string $regex): bool
     {
         foreach ($errorMessages as $error) {
-            $string = is_array($error) && array_key_exists('html', $error)
-                ? $error['html']
-                : (string)$error;
-
-            if (preg_match($regex, $string)) {
+            if (preg_match($regex, (string) $error)) {
                 return true;
             }
         }
@@ -690,7 +685,7 @@ class BundleControllerTest extends StoreTestCase
         );
 
         $this->actingAs($this->centreUser, 'store')
-            ->post($collectRoute, array_merge(
+            ->put($collectRoute, array_merge(
                 $this->defaultDisbursalData(),
                 ['trader_id' => $trader->id],
             ));
@@ -724,7 +719,7 @@ class BundleControllerTest extends StoreTestCase
         );
 
         $this->actingAs($this->centreUser, 'store')
-            ->post($collectRoute, array_merge(
+            ->put($collectRoute, array_merge(
                 $this->defaultDisbursalData(),
                 ['trader_id' => $trader->id],
             ));
@@ -743,7 +738,7 @@ class BundleControllerTest extends StoreTestCase
         $trader = factory(Trader::class)->create();
 
         $response = $this->actingAs($this->centreUser, 'store')
-            ->post($collectRoute, array_merge(
+            ->put($collectRoute, array_merge(
                 $this->defaultDisbursalData(),
                 ['trader_id' => $trader->id],
             ));
@@ -815,7 +810,7 @@ class BundleControllerTest extends StoreTestCase
         );
 
         $response = $this->actingAs($this->centreUser, 'store')
-            ->post($collectRoute, array_merge(
+            ->put($collectRoute, array_merge(
                 $this->defaultDisbursalData(),
                 ['trader_id' => $trader->id],
             ));

--- a/tests/Unit/Controllers/Store/BundleControllerTest.php
+++ b/tests/Unit/Controllers/Store/BundleControllerTest.php
@@ -2,60 +2,54 @@
 
 namespace Tests\Unit\Controllers\Store;
 
-use App\Registration;
 use App\Bundle;
 use App\Centre;
 use App\CentreUser;
 use App\Family;
+use App\Registration;
 use App\Sponsor;
 use App\Voucher;
-use Auth;
 use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Session;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Session;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\StoreTestCase;
 
 class BundleControllerTest extends StoreTestCase
 {
     use RefreshDatabase;
 
-    protected $centre;
-    protected $centreUser;
-    protected $testCodes;
+    protected Centre $centre;
+    protected CentreUser $centreUser;
     protected Registration $registration;
-    protected $bundle;
+    protected array $testCodes;
+    protected string $programme;
 
     protected function setUp(): void
     {
         parent::setUp();
+
         $this->centre = factory(Centre::class)->create();
 
-        // Create a User
         $this->centreUser = factory(CentreUser::class)->create([
-            "name"  => "test user",
-            "email" => "testuser@example.com",
-            "password" => bcrypt('test_user_pass'),
+            'name' => 'test user',
+            'email' => 'testuser@example.com',
+            'password' => bcrypt('test_user_pass'),
         ]);
         $this->centreUser->centres()->attach($this->centre->id, ['homeCentre' => true]);
 
-        //  A Registration on that centre
         $this->registration = factory(Registration::class)->create([
-            'centre_id' => $this->centre->id
+            'centre_id' => $this->centre->id,
         ]);
 
-        // Make some vouchers
-        $this->testCodes = [
-            'TST09999',
-            'TST10000',
-            'TST10001'
-        ];
+        $this->testCodes = ['TST09999', 'TST10000', 'TST10001'];
 
+        // Auth context is required by the voucher state-machine transition logger.
         Auth::login($this->centreUser);
 
-        foreach ($this->testCodes as $testCode) {
-            $voucher = factory(Voucher::class)->state('printed')->create([
-                'code' => $testCode
-            ]);
+        foreach ($this->testCodes as $code) {
+            $voucher = factory(Voucher::class)->state('printed')->create(['code' => $code]);
             $voucher->applyTransition('dispatch');
         }
 
@@ -64,658 +58,538 @@ class BundleControllerTest extends StoreTestCase
         Auth::logout();
     }
 
+    // -------------------------------------------------------------------------
+    // Append-vouchers validation — data provider
+    // -------------------------------------------------------------------------
 
-    public function testICannotSubmitInvalidValuesToAppendVouchers(): void
+    /**
+     * @return array<string, array{array<string,string>, string, string}>
+     *
+     * Config placeholders: config() is unavailable in static providers (they are constructed
+     * before the Laravel application boots). Two placeholders are used instead and resolved
+     * inside the test method once the container is live:
+     *   :max:          → config('arc.bundle_max_voucher_append')
+     *   :max_plus_one: → config('arc.bundle_max_voucher_append') + 1
+     */
+    public static function appendVoucherValidationCases(): array
     {
-        $dataSets = [
-            // no data
-            [
-                "data" => [],
-                "outcome" => ["start" => "The start field is required."]
+        return [
+            // --- start field (voucher-quantity absent branch) ---
+            'start: absent with no data submitted' => [
+                [],
+                'start',
+                'The start field is required when voucher-quantity is not present.',
             ],
-            // start is not present
-            [
-                "data" => ['end' => 'tst10001'],
-                "outcome" => ["start" => "The start field is required."]
+            'start: absent when only end supplied' => [
+                ['end' => 'tst10001'],
+                'start',
+                'The start field is required when voucher-quantity is not present.',
             ],
-            // start is present but null
-            [
-                "data" => ["start" => '', 'end' => 'tst10001'],
-                "outcome" => ["start" => "The start field is required."]
+            'start: empty string stripped by prepareForValidation' => [
+                ['start' => '', 'end' => 'tst10001'],
+                'start',
+                'The start field is required when voucher-quantity is not present.',
             ],
-            // start is not a valid voucher code
-            [
-                "data" => ["start" => 'invalidVoucher', 'end' => 'tst10001' ],
-                "outcome" => ["start" => "The selected start is invalid."]
+            'start: value not found in vouchers table' => [
+                ['start' => 'invalidVoucher', 'end' => 'tst10001'],
+                'start',
+                'The selected start is invalid.',
             ],
-            // end is not a valid voucher code
-            [
-                "data" => ["start" => 'tst09999', 'end' => 'invalidCode' ],
-                "outcome" => ["end" => "The selected end is invalid."]
+
+            // --- end field ---
+            'end: value not found in vouchers table' => [
+                ['start' => 'tst09999', 'end' => 'invalidCode'],
+                'end',
+                'The selected end is invalid.',
             ],
-            // end is not the same shortcode as start
-            [
-                "data" => ["start" => 'tst09999', 'end' => 'txt10000' ],
-                "outcome" => ["end" => "The end field must be the same sponsor as the start field."]
+            'end: different sponsor prefix to start' => [
+                ['start' => 'tst09999', 'end' => 'txt10000'],
+                'end',
+                'The end field must be the same sponsor as the start field.',
             ],
-            // end is not higher than start
-            [
-                "data" => ["start" => 'tst10001', 'end' => 'tst09999' ],
-                "outcome" => ["end" => "The end field must be greater than the start field."]
+            'end: lower sequence number than start' => [
+                ['start' => 'tst10001', 'end' => 'tst09999'],
+                'end',
+                'The end field must be greater than the start field.',
+            ],
+
+            // --- voucher-quantity field (early-return branch) ---
+            'voucher-quantity: zero is below the allowed minimum of 1' => [
+                ['voucher-quantity' => '0'],
+                'voucher-quantity',
+                'The voucher-quantity must be between 1 and :max:.',
+            ],
+            'voucher-quantity: negative value is below the allowed minimum of 1' => [
+                ['voucher-quantity' => '-1'],
+                'voucher-quantity',
+                'The voucher-quantity must be between 1 and :max:.',
+            ],
+            'voucher-quantity: exceeds the configured maximum' => [
+                ['voucher-quantity' => ':max_plus_one:'],
+                'voucher-quantity',
+                'The voucher-quantity must be between 1 and :max:.',
+            ],
+            'voucher-quantity: required when start also absent' => [
+                [],
+                'voucher-quantity',
+                'The voucher-quantity field is required when start is not present.',
             ],
         ];
-
-        $route = route('store.registration.voucher-manager', [ 'registration' => $this->registration->id ]);
-        $post_route = route('store.registration.vouchers.post', [ 'registration' => $this->registration->id ]);
-
-        foreach ($dataSets as $set) {
-            $response = $this->actingAs($this->centreUser, 'store')
-                ->visit($route)
-                ->post(
-                    $post_route,
-                    $set["data"]
-                )
-            ;
-            // work out which field we're testing.
-            $field = array_keys($set['outcome'])[0];
-
-            // Dig out errors from Session
-            $all = session()->all();
-            self::assertArrayHasKey("errors", $all);
-            $errors = session("errors")->get($field);
-
-            // Check our specific message is present
-            $this->assertContains($set['outcome'][$field], $errors);
-
-            // we follow that to the correct page;
-            $this->followRedirects()
-                ->seePageIs($route)
-                ->assertResponseStatus(200)
-            ;
-        }
     }
 
-
-    public function testIMustDisburseWithAllRelevantFields(): void
-    {
-        $dataSets = [
-            [
-                "data" => [
-                    "collected_at" => "1", "collected_on" => "2018-07-21"
-                ],
-                "outcome" => [ "collected_by" => "The collected by field is required when collected at / collected on is present."],
-            ],
-            [
-                "data" => [
-                    "collected_by" => "1", "collected_on" => "2018-07-21"
-                ],
-                "outcome" => [ "collected_at" => "The collected at field is required when collected on / collected by is present."],
-            ],
-            [
-                "data" => [
-                    "collected_at" => "1", "collected_by" => "1"
-                ],
-                "outcome" => [ "collected_on" => "The collected on field is required when collected at / collected by is present."],
-            ],
-            [
-                "data" => [
-                    "collected_at" => "1", "collected_on" => "invalid", "collected_by" => "1"
-                ],
-                "outcome" => [ "collected_on" => "The collected on does not match the format Y-m-d."],
-            ],
-            [
-                "data" => [
-                    "collected_at" => "9999", "collected_on" => "2018-07-21", "collected_by" => "1"
-                ],
-                "outcome" => [ "collected_at" => "The selected collected at is invalid."],
-            ],
-            [
-                "data" => [
-                    "collected_at" => "1", "collected_on" => "2018-07-21", "collected_by" => "9999"
-                ],
-                "outcome" => [ "collected_by" => "The selected collected by is invalid."],
-            ],
-        ];
-
-        $route = route('store.registration.voucher-manager', [ 'registration' => $this->registration->id ]);
-        $put_route = route('store.registration.vouchers.put', ['registration' => $this->registration->id]);
-
-        foreach ($dataSets as $set) {
-            $response = $this->actingAs($this->centreUser, 'store')
-                ->visit($route)
-                ->put(
-                    $put_route,
-                    $set["data"]
-                )
-            ;
-            // work out which field we're testing.
-            $field = array_keys($set['outcome'])[0];
-
-            // Dig out errors from Session
-            $response->seeInSession('errors');
-            $errors = Session::get("errors")->get($field);
-
-            // Check our specific message is present
-            $this->assertContains($set['outcome'][$field], $errors);
-
-            // we follow that to the correct page;
-            $this->followRedirects()
-                ->seePageIs($route)
-                ->assertResponseStatus(200)
-            ;
-        }
-    }
-
-
-    public function testICanAddManyVouchers(): void
-    {
-        $route = route('store.registration.voucher-manager', [ 'registration' => $this->registration->id ]);
-        $post_route = route('store.registration.vouchers.post', [ 'registration' => $this->registration->id ]);
-
-        // Add many vouchers;
-        $this->actingAs($this->centreUser, 'store')
-            ->post(
-                $post_route,
-                [
-                    'start' => $this->testCodes[0],
-                    'end' => $this->testCodes[count($this->testCodes) - 1]
-                ]
-            );
-
-        $this->followRedirects()
-            ->seePageIs($route)
-            ->assertResponseStatus(200)
-        ;
-        /** @var Bundle $currentBundle */
-        // Get our currentBundle
-        $currentBundle = $this->registration->currentBundle();
-
-        // See that it's got many vouchers.
-        $this->assertEquals(count($this->testCodes), $currentBundle->vouchers()->count());
-    }
-
-
-    public function testICannotAddTooManyVouchersToABundle(): void
-    {
-        $route = route('store.registration.voucher-manager', [ 'registration' => $this->registration->id ]);
-        $post_route = route('store.registration.vouchers.post', [ 'registration' => $this->registration->id ]);
-
-        // Get the maxAdd value currently 101;
-        $overMaxAdd = config('arc.bundle_max_voucher_append') + 1;
-
-        // Make the range 1-101,
-        $startCode = "BIG00001";
-        $endCode = "BIG" . str_pad($overMaxAdd, 5, "0", STR_PAD_LEFT);
-        $bigRange = Voucher::generateCodeRange($startCode, $endCode);
-        $this->assertCount($overMaxAdd, $bigRange);
-
-        // Create the vouchers for the range;
-        Auth::login($this->centreUser);
-        foreach ($bigRange as $testCode) {
-            $voucher = factory(Voucher::class)->state('printed')->create([
-                'code' => $testCode
-            ]);
-            $voucher->applyTransition('dispatch');
-        }
-        Auth::logout();
-
-        // Attempt to bind the vouchers to the bundle
-        $response = $this->actingAs($this->centreUser, 'store')
-            ->post(
-                $post_route,
-                [
-                    'start' => $startCode,
-                    'end' => $endCode,
-                ]
-            );
-
-        // Confirm that we have supplied the appropriate error message to the session
-        $response->seeInSession('error_messages');
-        $this->assertTrue($this->hasMatchingErrorMessage(
-            Session::get('error_messages'),
-            '/Failed adding more than ' . config('arc.bundle_max_voucher_append') . ' vouchers/'
-        ));
-
-        // see we're redirected back
-        $this->followRedirects()
-            ->seePageIs($route)
-            ->assertResponseStatus(200)
-        ;
-
-        // See we have no vouchers added.
-        /** @var Bundle $currentBundle */
-        // Get our currentBundle
-        $currentBundle = $this->registration->currentBundle();
-
-        // See that it's got no vouchers.
-        $this->assertEquals(0, $currentBundle->vouchers()->count());
-    }
-
-
-    public function testICanAddSingleVouchers(): void
-    {
-        $route = route('store.registration.voucher-manager', [ 'registration' => $this->registration->id ]);
-        $post_route = route('store.registration.vouchers.post', [ 'registration' => $this->registration->id ]);
-
-        // Add a voucher;
-        $this->actingAs($this->centreUser, 'store')
-            ->post($post_route, ['start' => $this->testCodes[0]]);
-
-        $this->followRedirects()
-            ->seePageIs($route)
-            ->assertResponseStatus(200)
-        ;
-
-        /** @var Bundle $currentBundle */
-        // Get our currentBundle
-        $currentBundle = $this->registration->currentBundle();
-
-        // See that it's got one voucher.
-        $this->assertEquals(1, $currentBundle->vouchers()->count());
-    }
-
-
-
-    public function testICanDeleteTheCurrentBundle(): void
-    {
-        /** @var Bundle $currentBundle */
-        $currentBundle = $this->registration->currentBundle();
-
-        Auth::login($this->centreUser);
-        // Make some vouchers to bundle.
-        $testCodes = [
-            'TST0123455',
-            'TST0123456',
-            'TST0123457'
-        ];
-        foreach ($testCodes as $testCode) {
-            $voucher = factory(Voucher::class)->state('printed')->create([
-                'code' => $testCode
-            ]);
-            $voucher->applyTransition('dispatch');
-            $voucher->bundle()->associate($currentBundle)->save();
-        }
-
-        // there should be 3 vouchers!
-        $this->assertEquals(count($testCodes), $currentBundle->vouchers()->count());
-
-        // Stash vouchers for test later
-        //$vouchers = $currentBundle->vouchers()->get();
-
-        $delete_route = route(
-            'store.registration.vouchers.delete',
-            [
-                'registration' => $this->registration->id,
-            ]
-        );
-
-        // Hit the route with a delete request;
-        $this->actingAs($this->centreUser, 'store')
-            ->delete($delete_route)
-        ;
-
-        // refresh bundle
-        $currentBundle->refresh();
-        // See less vouchers
-        $this->assertEquals(0, $currentBundle->vouchers()->count());
-
-        //Check all vouchers have NULL bundle_id
-
-        $vouchers = Voucher::whereIn('code', $testCodes)->get();
-        foreach ($vouchers as $v) {
-            $this->assertNull($v->bundle_id);
-        }
-    }
-
-
-    public function testICanDeleteANamedVoucher(): void
-    {
-        /** @var Bundle $currentBundle */
-        $currentBundle = $this->registration->currentBundle();
-
-        Auth::login($this->centreUser);
-        // Make some vouchers to bundle.
-        $testCodes = [
-            'TST0123455',
-            'TST0123456',
-            'TST0123457'
-        ];
-        foreach ($testCodes as $testCode) {
-            $voucher = factory(Voucher::class)->state('printed')->create([
-                'code' => $testCode
-            ]);
-            $voucher->applyTransition('dispatch');
-            $voucher->bundle()->associate($currentBundle)->save();
-        }
-
-        // there should be 3 vouchers!
-        $this->assertEquals(count($testCodes), $currentBundle->vouchers()->count());
-
-        // find the first voucher
-        $voucher = $currentBundle->vouchers()->first();
-
-        $delete_route = route(
-            'store.registration.voucher.delete',
-            [
-                'registration' => $this->registration->id,
-                'voucher' => $voucher->id
-            ]
-        );
-
-        // Hit the route with a delete request;
-        $this->actingAs($this->centreUser, 'store')
-            ->delete($delete_route)
-        ;
-
-        // refresh bundle
-        $currentBundle->refresh();
-        // See less vouchers
-        $this->assertEquals(count($testCodes) - 1, $currentBundle->vouchers()->count());
-
-        // Refresh the detached voucher
-        $voucher->refresh();
-        // Assert voucher is unbundled
-        $this->assertNull($voucher->bundle_id);
-
-        // Assert voucher is back to dispatched
-        $this->assertEquals('dispatched', $voucher->currentstate);
-    }
-
-
-    public function testICanSyncAnArrayOfVouchers(): void
-    {
-        $put_route = route('store.registration.vouchers.put', ['registration' => $this->registration->id]);
-
-        // sync a voucher;
-        $this->actingAs($this->centreUser, 'store')
-            ->put($put_route, ['vouchers' => [$this->testCodes[0]]]);
-
-        $currentBundle = $this->registration->currentBundle();
-        $this->assertEquals(1, $currentBundle->vouchers()->count());
-
-        // re-sync with 3 vouchers
-        $this->actingAs($this->centreUser, 'store')
-            ->put($put_route, ['vouchers' => $this->testCodes]);
-
-        $currentBundle->refresh();
-        $this->assertEquals(count($this->testCodes), $currentBundle->vouchers()->count());
-
-        // sync without a voucher array AT ALL - does nothing.
-        $this->actingAs($this->centreUser, 'store')
-            ->put($put_route, []);
-
-        $currentBundle->refresh();
-        $this->assertEquals(count($this->testCodes), $currentBundle->vouchers()->count());
-
-        // sync with only a single empty voucher string erases the vouchers.
-        $this->assertEquals(3, $currentBundle->vouchers()->count());
-
-        $this->actingAs($this->centreUser, 'store')
-            ->put($put_route, ['vouchers' => [''] ]);
-
-        $currentBundle->refresh();
-        $this->assertEquals(0, $currentBundle->vouchers()->count());
-    }
-
-
-    public function testICannotDisburseAnEmptyBundle(): void
-    {
-        // Setup bundle
-        $currentBundle = $this->registration->currentBundle();
-
-        Auth::login($this->centreUser);
-
-        // There should be one currentBundle with 3 vouchers
-        $this->assertCount(1, $this->registration->bundles);
-
-        // Create a sensible place to have collected it.
-        $disbursementCentre = Auth::user()->centre->id;
-
-        // Create a sensible date to have Collected on
-        $disbursementDate = Carbon::now()->startOfWeek()->format("Y-m-d");
-
-        // Find a carer for bundle
-        $collectingCarer = $this->registration->family->carers->first()->id;
-
-        // Array all that
-        $data = [
-            "collected_at" => $disbursementCentre,
-            "collected_on" => $disbursementDate,
-            "collected_by" => $collectingCarer
-        ];
+    #[DataProvider('appendVoucherValidationCases')]
+    public function testICannotSubmitInvalidValuesToAppendVouchers(
+        array $data,
+        string $field,
+        string $expectedMessage,
+    ): void {
+        $max = (string)config('arc.bundle_max_voucher_append');
+
+        // Resolve placeholders that cannot be evaluated inside a static data provider.
+        $data = array_map(static function (string $v) use ($max) {
+            return str_replace(':max_plus_one:', (string)((int)$max + 1), $v);
+        }, $data);
+        $expectedMessage = str_replace(':max:', $max, $expectedMessage);
 
         $route = route('store.registration.voucher-manager', ['registration' => $this->registration->id]);
-        $put_route = route('store.registration.vouchers.put', ['registration' => $this->registration->id]);
+        $postRoute = route('store.registration.vouchers.post', ['registration' => $this->registration->id]);
 
-        // Attempt to submit
-        $response = $this->actingAs($this->centreUser, 'store')
+        $this->actingAs($this->centreUser, 'store')
             ->visit($route)
-            ->put(
-                $put_route,
-                $data
-            );
+            ->post($postRoute, $data);
 
-        // Confirm that we have supplied the appropriate error message to the session
-        $response->seeInSession('error_messages');
-        $this->assertTrue($this->hasMatchingErrorMessage(
-            Session::get('error_messages'),
-            '/Action denied on empty bundle/'
-        ));
+        $errors = session('errors')->get($field);
 
-        // Check the submission was a success
+        $this->assertNotEmpty($errors, "Expected validation errors for field '$field'");
+        $this->assertContains($expectedMessage, $errors);
+
         $this->followRedirects()
             ->seePageIs($route)
             ->assertResponseStatus(200);
     }
 
+    // -------------------------------------------------------------------------
+    // Disbursement validation — data provider
+    // -------------------------------------------------------------------------
 
-    public function testICannotAddAVoucherAllocatedInACentreIHaveAccessTo(): void
+    /**
+     * @return array<string, array{array<string,string>, string, string}>
+     */
+    public static function disburseValidationCases(): array
     {
-        $route = route('store.registration.voucher-manager', [ 'registration' => $this->registration->id ]);
-        $post_route = route('store.registration.vouchers.post', [ 'registration' => $this->registration->id ]);
-
-        // Add a voucher to the registration's bundle
-        $this->actingAs($this->centreUser, 'store')
-        ->visit($route)
-        ->post(
-            $post_route,
-            ["start" => $this->testCodes[0]]
-        );
-
-        // Add a second registration in the same centre
-        $this->registrationTwo = factory(Registration::class)->create([
-            'centre_id' => $this->centre->id
-        ]);
-
-        $route_2 = route('store.registration.voucher-manager', [ 'registration' => $this->registrationTwo->id ]);
-        $post_route_2 = route('store.registration.vouchers.post', [ 'registration' => $this->registrationTwo->id ]);
-
-        // Attempt to post the same voucher code into the second registration's bundle
-        $response = $this->actingAs($this->centreUser, 'store')
-        ->visit($route_2)
-        ->post(
-            $post_route_2,
-            ["start" => $this->testCodes[0]]
-        );
-
-        // See we have no vouchers added.
-        /** @var Bundle $currentBundle */
-        // Get our currentBundle
-        $currentBundle = $this->registrationTwo->currentBundle();
-
-        // See that it's got no vouchers.
-        $this->assertEquals(0, $currentBundle->vouchers()->count());
-
-        // Check the expected error message is in the session
-        $response->seeInSession('error_messages');
-        $entity = Family::getAlias($this->programme);
-        $this->assertTrue($this->hasMatchingErrorMessage(
-            Session::get('error_messages'),
-            '~These vouchers are currently allocated to a different ' . $entity . '. Click on the voucher number to view the other ' . $entity . '\'s record: <a href="' . $route . '">' . $this->testCodes[0] . '</a>~'
-        ));
-
-        // Check the expected error message is in the view
-        $this->followRedirects()
-            ->seeInElement('div[class="alert-message error"]', 'Click on the voucher number to view the other ' . $entity . '\'s record: <a href="' . $route . '">' . $this->testCodes[0] . '</a>');
+        return [
+            'collected_by missing' => [
+                ['collected_at' => '1', 'collected_on' => '2018-07-21'],
+                'collected_by',
+                'The collected by field is required when collected at / collected on is present.',
+            ],
+            'collected_at missing' => [
+                ['collected_by' => '1', 'collected_on' => '2018-07-21'],
+                'collected_at',
+                'The collected at field is required when collected on / collected by is present.',
+            ],
+            'collected_on missing' => [
+                ['collected_at' => '1', 'collected_by' => '1'],
+                'collected_on',
+                'The collected on field is required when collected at / collected by is present.',
+            ],
+            'collected_on wrong date format' => [
+                ['collected_at' => '1', 'collected_on' => 'invalid', 'collected_by' => '1'],
+                'collected_on',
+                'The collected on does not match the format Y-m-d.',
+            ],
+            'collected_at centre does not exist' => [
+                ['collected_at' => '9999', 'collected_on' => '2018-07-21', 'collected_by' => '1'],
+                'collected_at',
+                'The selected collected at is invalid.',
+            ],
+            'collected_by carer does not exist' => [
+                ['collected_at' => '1', 'collected_on' => '2018-07-21', 'collected_by' => '9999'],
+                'collected_by',
+                'The selected collected by is invalid.',
+            ],
+        ];
     }
 
+    #[DataProvider('disburseValidationCases')]
+    public function testIMustDisburseWithAllRelevantFields(
+        array $data,
+        string $field,
+        string $expectedMessage,
+    ): void {
+        $route = route('store.registration.voucher-manager', ['registration' => $this->registration->id]);
+        $putRoute = route('store.registration.vouchers.put', ['registration' => $this->registration->id]);
 
-    public function testICannotAddAVoucherAllocatedInACentreIDoNotHaveAccessTo(): void
-    {
-        $route = route('store.registration.voucher-manager', [ 'registration' => $this->registration->id ]);
-        $post_route = route('store.registration.vouchers.post', [ 'registration' => $this->registration->id ]);
-
-        // Add a voucher to the registration's bundle
         $this->actingAs($this->centreUser, 'store')
-        ->visit($route)
-        ->post(
-            $post_route,
-            ["start" => $this->testCodes[1]]
-        );
+            ->visit($route)
+            ->put($putRoute, $data);
 
-        // Create a second sponsor, centre and user
-        $this->sponsor2 = factory(Sponsor::class)->create();
+        $errors = session('errors')->get($field);
 
-        $this->centre2 = factory(Centre::class)->create(["sponsor_id" => $this->sponsor2->id]);
-
-        $this->centreUser2 = factory(CentreUser::class)->create([
-            "name"  => "second test user",
-            "email" => "testuser2@example.com",
-            "password" => bcrypt('test_user_pass2'),
-            "role" => "centre_user"
-        ]);
-
-        $this->centreUser2->centres()->attach($this->centre2->id, ['homeCentre' => true]);
-
-        // Add a registration to the second centre
-        $this->registrationTwo = factory(Registration::class)->create([
-            'centre_id' => $this->centre2->id
-        ]);
-
-        $route_2 = route('store.registration.voucher-manager', [ 'registration' => $this->registrationTwo->id ]);
-        $post_route_2 = route('store.registration.vouchers.post', [ 'registration' => $this->registrationTwo->id ]);
-
-        // Attempt to post the same voucher code into the second registration's bundle
-        $response = $this->actingAs($this->centreUser2, 'store')
-        ->visit($route_2)
-        ->post(
-            $post_route_2,
-            ["start" => $this->testCodes[1]]
-        );
-
-        // See we have no vouchers added.
-        /** @var Bundle $currentBundle */
-        // Get our currentBundle
-        $currentBundle = $this->registrationTwo->currentBundle();
-
-        // See that it's got no vouchers.
-        $this->assertEquals(0, $currentBundle->vouchers()->count());
-        $entity = Family::getAlias($this->programme);
-        // Check the expected error message is in the session
-        $response->seeInSession('error_messages');
-        //dd(Session::get('error_messages'));
-        $this->assertTrue($this->hasMatchingErrorMessage(
-            Session::get('error_messages'),
-            '~These vouchers are allocated to a different ' . $entity . ' in a centre you can\'t access: ' . $this->testCodes[1] . '~'
-        ));
-
-
-        // Check the expected error message is in the view
-        $this->followRedirects()
-        ->seeInElement('div[class="alert-message error"]', 'These vouchers are allocated to a different ' . $entity . ' in a centre you can\'t access: ' . $this->testCodes[1]);
-    }
-
-
-    public function testItCanAcceptAndCleanVouchersWithSpacesIn(): void
-    {
-        $route = route('store.registration.voucher-manager', [ 'registration' => $this->registration->id ]);
-        $post_route = route('store.registration.vouchers.post', [ 'registration' => $this->registration->id ]);
-
-        // Create a voucherCode with a space in from the test list
-        $voucherCode = $this->testCodes[0];
-        $randPos = rand(0, strlen($voucherCode));
-        $voucherCode = substr_replace($voucherCode, " ", $randPos, 0);
-
-        // Add a voucher;
-        $this->actingAs($this->centreUser, 'store')
-            ->post($post_route, ['start' => $voucherCode]);
+        $this->assertNotEmpty($errors, "Expected validation errors for field '$field'");
+        $this->assertContains($expectedMessage, $errors);
 
         $this->followRedirects()
             ->seePageIs($route)
-            ->assertResponseStatus(200)
-        ;
-
-        /** @var Bundle $currentBundle */
-        // Get our currentBundle
-        $currentBundle = $this->registration->currentBundle();
-
-        // See that it's got one voucher.
-        $this->assertEquals(1, $currentBundle->vouchers()->count());
+            ->assertResponseStatus(200);
     }
 
+    // -------------------------------------------------------------------------
+    // Adding vouchers to a bundle
+    // -------------------------------------------------------------------------
+
+    public function testICanAddSingleVouchers(): void
+    {
+        $route = route('store.registration.voucher-manager', ['registration' => $this->registration->id]);
+        $postRoute = route('store.registration.vouchers.post', ['registration' => $this->registration->id]);
+
+        $this->actingAs($this->centreUser, 'store')
+            ->post($postRoute, ['start' => $this->testCodes[0]]);
+
+        $this->followRedirects()
+            ->seePageIs($route)
+            ->assertResponseStatus(200);
+
+        $this->assertSame(1, $this->registration->currentBundle()->vouchers()->count());
+    }
+
+    public function testICanAddManyVouchers(): void
+    {
+        $route = route('store.registration.voucher-manager', ['registration' => $this->registration->id]);
+        $postRoute = route('store.registration.vouchers.post', ['registration' => $this->registration->id]);
+
+        $this->actingAs($this->centreUser, 'store')
+            ->post($postRoute, [
+                'start' => $this->testCodes[0],
+                'end' => $this->testCodes[count($this->testCodes) - 1],
+            ]);
+
+        $this->followRedirects()
+            ->seePageIs($route)
+            ->assertResponseStatus(200);
+
+        $this->assertSame(count($this->testCodes), $this->registration->currentBundle()->vouchers()->count());
+    }
+
+    public function testICannotAddTooManyVouchersToABundle(): void
+    {
+        $route = route('store.registration.voucher-manager', ['registration' => $this->registration->id]);
+        $postRoute = route('store.registration.vouchers.post', ['registration' => $this->registration->id]);
+
+        $overMaxAdd = config('arc.bundle_max_voucher_append') + 1;
+        $startCode = 'BIG00001';
+        $endCode = 'BIG' . str_pad((string)$overMaxAdd, 5, '0', STR_PAD_LEFT);
+        $bigRange = Voucher::generateCodeRange($startCode, $endCode);
+
+        $this->assertCount($overMaxAdd, $bigRange);
+
+        Auth::login($this->centreUser);
+        foreach ($bigRange as $code) {
+            $voucher = factory(Voucher::class)->state('printed')->create(['code' => $code]);
+            $voucher->applyTransition('dispatch');
+        }
+        Auth::logout();
+
+        $response = $this->actingAs($this->centreUser, 'store')
+            ->post($postRoute, ['start' => $startCode, 'end' => $endCode]);
+
+        $response->seeInSession('error_messages');
+        $this->assertTrue($this->hasMatchingErrorMessage(
+            Session::get('error_messages'),
+            '/Failed adding more than ' . config('arc.bundle_max_voucher_append') . ' vouchers/',
+        ));
+
+        $this->followRedirects()
+            ->seePageIs($route)
+            ->assertResponseStatus(200);
+
+        $this->assertSame(0, $this->registration->currentBundle()->vouchers()->count());
+    }
+
+    public function testICannotAddAVoucherAllocatedInACentreIHaveAccessTo(): void
+    {
+        $route = route('store.registration.voucher-manager', ['registration' => $this->registration->id]);
+        $postRoute = route('store.registration.vouchers.post', ['registration' => $this->registration->id]);
+
+        // Allocate the first test voucher to the primary registration.
+        $this->actingAs($this->centreUser, 'store')
+            ->post($postRoute, ['start' => $this->testCodes[0]]);
+
+        // Create a second registration in the same centre.
+        $registrationTwo = factory(Registration::class)->create(['centre_id' => $this->centre->id]);
+
+        $route2 = route('store.registration.voucher-manager', ['registration' => $registrationTwo->id]);
+        $postRoute2 = route('store.registration.vouchers.post', ['registration' => $registrationTwo->id]);
+
+        // Attempt to add the already-allocated voucher to the second bundle.
+        $response = $this->actingAs($this->centreUser, 'store')
+            ->visit($route2)
+            ->post($postRoute2, ['start' => $this->testCodes[0]]);
+
+        $this->assertSame(0, $registrationTwo->currentBundle()->vouchers()->count());
+
+        $response->seeInSession('error_messages');
+
+        $entity = Family::getAlias($this->programme);
+        $expectedPattern = '~These vouchers are currently allocated to a different ' . $entity
+            . '. Click on the voucher number to view the other ' . $entity
+            . '\'s record: <a href="' . $route . '">' . $this->testCodes[0] . '</a>~';
+
+        $this->assertTrue($this->hasMatchingErrorMessage(Session::get('error_messages'), $expectedPattern));
+
+        $this->followRedirects()
+            ->seeInElement(
+                'div[class="alert-message error"]',
+                'Click on the voucher number to view the other ' . $entity
+                . '\'s record: <a href="' . $route . '">' . $this->testCodes[0] . '</a>',
+            );
+    }
+
+    public function testICannotAddAVoucherAllocatedInACentreIDoNotHaveAccessTo(): void
+    {
+        $postRoute = route('store.registration.vouchers.post', ['registration' => $this->registration->id]);
+
+        // Allocate the second test voucher to the primary registration.
+        $this->actingAs($this->centreUser, 'store')
+            ->post($postRoute, ['start' => $this->testCodes[1]]);
+
+        // Build a completely separate sponsor / centre / user / registration hierarchy.
+        $sponsor2 = factory(Sponsor::class)->create();
+        $centre2 = factory(Centre::class)->create(['sponsor_id' => $sponsor2->id]);
+        $centreUser2 = factory(CentreUser::class)->create([
+            'name' => 'second test user',
+            'email' => 'testuser2@example.com',
+            'password' => bcrypt('test_user_pass2'),
+            'role' => 'centre_user',
+        ]);
+        $centreUser2->centres()->attach($centre2->id, ['homeCentre' => true]);
+
+        $registrationTwo = factory(Registration::class)->create(['centre_id' => $centre2->id]);
+
+        $route2 = route('store.registration.voucher-manager', ['registration' => $registrationTwo->id]);
+        $postRoute2 = route('store.registration.vouchers.post', ['registration' => $registrationTwo->id]);
+
+        $response = $this->actingAs($centreUser2, 'store')
+            ->visit($route2)
+            ->post($postRoute2, ['start' => $this->testCodes[1]]);
+
+        $this->assertSame(0, $registrationTwo->currentBundle()->vouchers()->count());
+
+        $response->seeInSession('error_messages');
+
+        $entity = Family::getAlias($this->programme);
+        $expectedPattern = '~These vouchers are allocated to a different ' . $entity
+            . ' in a centre you can\'t access: ' . $this->testCodes[1] . '~';
+
+        $this->assertTrue($this->hasMatchingErrorMessage(Session::get('error_messages'), $expectedPattern));
+
+        $this->followRedirects()
+            ->seeInElement(
+                'div[class="alert-message error"]',
+                'These vouchers are allocated to a different ' . $entity
+                . ' in a centre you can\'t access: ' . $this->testCodes[1],
+            );
+    }
+
+    // -------------------------------------------------------------------------
+    // Input cleaning
+    // -------------------------------------------------------------------------
+
+    public function testItCanAcceptAndCleanVouchersWithSpacesIn(): void
+    {
+        $route = route('store.registration.voucher-manager', ['registration' => $this->registration->id]);
+        $postRoute = route('store.registration.vouchers.post', ['registration' => $this->registration->id]);
+
+        // Insert a space at a random position in the voucher code.
+        $voucherCode = $this->testCodes[0];
+        $voucherCode = substr_replace($voucherCode, ' ', random_int(0, strlen($voucherCode)), 0);
+
+        $this->actingAs($this->centreUser, 'store')
+            ->post($postRoute, ['start' => $voucherCode]);
+
+        $this->followRedirects()
+            ->seePageIs($route)
+            ->assertResponseStatus(200);
+
+        $this->assertSame(1, $this->registration->currentBundle()->vouchers()->count());
+    }
 
     public function testItHasSparseFormDataCleanedBeforeProcessing(): void
     {
-        $route = route('store.registration.voucher-manager', [ 'registration' => $this->registration->id ]);
-        $post_route = route('store.registration.vouchers.post', [ 'registration' => $this->registration->id ]);
+        $postRoute = route('store.registration.vouchers.post', ['registration' => $this->registration->id]);
 
-        $data_null_end = [
-            'start' => $this->testCodes[0],
-            'end' => null
-        ];
-
-        $data_blank_end = [
-            'start' => $this->testCodes[1],
-            'end' => ''
-        ];
-
-        // Add null end voucher;
+        // A null end should be treated as a single-code add.
         $this->actingAs($this->centreUser, 'store')
-            ->post(
-                $post_route,
-                $data_null_end
-            );
+            ->post($postRoute, ['start' => $this->testCodes[0], 'end' => null]);
 
-        // Expect to see last record is testCode[0]
-        $last_voucher = $this->registration
-            ->currentBundle()
-            ->vouchers()
-            ->orderByDesc('id')
-            ->first();
-        $this->assertEquals($this->testCodes[0], $last_voucher->code);
+        $lastVoucher = $this->registration->currentBundle()->vouchers()->orderByDesc('id')->first();
+        $this->assertSame($this->testCodes[0], $lastVoucher->code);
 
-        // Add empty string end vouchers;
+        // A blank-string end should also be treated as a single-code add.
         $this->actingAs($this->centreUser, 'store')
-            ->post(
-                $post_route,
-                $data_blank_end
-            );
+            ->post($postRoute, ['start' => $this->testCodes[1], 'end' => '']);
 
-        // Expect to see last record is testCode[1]
-        $last_voucher = $this->registration
-            ->currentBundle()
-            ->vouchers()
-            ->orderByDesc('id')
-            ->first();
-        $this->assertEquals($this->testCodes[1], $last_voucher->code);
+        $lastVoucher = $this->registration->currentBundle()->vouchers()->orderByDesc('id')->first();
+        $this->assertSame($this->testCodes[1], $lastVoucher->code);
     }
 
+    // -------------------------------------------------------------------------
+    // Sync (PUT)
+    // -------------------------------------------------------------------------
+
+    public function testICanSyncAnArrayOfVouchers(): void
+    {
+        $putRoute = route('store.registration.vouchers.put', ['registration' => $this->registration->id]);
+
+        // Sync a single voucher.
+        $this->actingAs($this->centreUser, 'store')
+            ->put($putRoute, ['vouchers' => [$this->testCodes[0]]]);
+
+        $currentBundle = $this->registration->currentBundle();
+        $this->assertSame(1, $currentBundle->vouchers()->count());
+
+        // Re-sync with all three vouchers.
+        $this->actingAs($this->centreUser, 'store')
+            ->put($putRoute, ['vouchers' => $this->testCodes]);
+
+        $currentBundle->refresh();
+        $this->assertSame(count($this->testCodes), $currentBundle->vouchers()->count());
+
+        // Sending no vouchers key at all leaves the bundle unchanged.
+        $this->actingAs($this->centreUser, 'store')
+            ->put($putRoute);
+
+        $currentBundle->refresh();
+        $this->assertSame(count($this->testCodes), $currentBundle->vouchers()->count());
+
+        // A single empty string in the vouchers array clears the bundle.
+        $this->actingAs($this->centreUser, 'store')
+            ->put($putRoute, ['vouchers' => ['']]);
+
+        $currentBundle->refresh();
+        $this->assertSame(0, $currentBundle->vouchers()->count());
+    }
+
+    // -------------------------------------------------------------------------
+    // Delete operations
+    // -------------------------------------------------------------------------
+
+    public function testICanDeleteTheCurrentBundle(): void
+    {
+        $currentBundle = $this->registration->currentBundle();
+        $deleteCodes = ['TST0123455', 'TST0123456', 'TST0123457'];
+
+        Auth::login($this->centreUser);
+        foreach ($deleteCodes as $code) {
+            $voucher = factory(Voucher::class)->state('printed')->create(['code' => $code]);
+            $voucher->applyTransition('dispatch');
+            $voucher->bundle()->associate($currentBundle)->save();
+        }
+        Auth::logout();
+
+        $this->assertSame(count($deleteCodes), $currentBundle->vouchers()->count());
+
+        $deleteRoute = route('store.registration.vouchers.delete', ['registration' => $this->registration->id]);
+
+        $this->actingAs($this->centreUser, 'store')
+            ->delete($deleteRoute);
+
+        $currentBundle->refresh();
+        $this->assertSame(0, $currentBundle->vouchers()->count());
+
+        // Every previously-bundled voucher should have a null bundle_id.
+        Voucher::whereIn('code', $deleteCodes)
+            ->each(function (Voucher $v) {
+                return $this->assertNull($v->bundle_id);
+            });
+    }
+
+    public function testICanDeleteANamedVoucher(): void
+    {
+        /** @var Bundle $currentBundle */
+        $currentBundle = $this->registration->currentBundle();
+        $bundledCodes = ['TST0123455', 'TST0123456', 'TST0123457'];
+
+        Auth::login($this->centreUser);
+        foreach ($bundledCodes as $code) {
+            $voucher = factory(Voucher::class)->state('printed')->create(['code' => $code]);
+            $voucher->applyTransition('dispatch');
+            $voucher->bundle()->associate($currentBundle)->save();
+        }
+        Auth::logout();
+
+        $this->assertSame(count($bundledCodes), $currentBundle->vouchers()->count());
+
+        /** @var Voucher $target */
+        $target = $currentBundle->vouchers()->first();
+        $deleteRoute = route('store.registration.voucher.delete', [
+            'registration' => $this->registration->id,
+            'voucher' => $target->id,
+        ]);
+
+        $this->actingAs($this->centreUser, 'store')
+            ->delete($deleteRoute);
+
+        $currentBundle->refresh();
+        $this->assertSame(count($bundledCodes) - 1, $currentBundle->vouchers()->count());
+
+        $target->refresh();
+        $this->assertNull($target->bundle_id);
+        $this->assertSame('dispatched', $target->currentstate);
+    }
+
+    // -------------------------------------------------------------------------
+    // Disbursement
+    // -------------------------------------------------------------------------
+
+    public function testICannotDisburseAnEmptyBundle(): void
+    {
+        $route = route('store.registration.voucher-manager', ['registration' => $this->registration->id]);
+        $putRoute = route('store.registration.vouchers.put', ['registration' => $this->registration->id]);
+
+        $data = [
+            'collected_at' => $this->centre->id,
+            'collected_on' => Carbon::now()->startOfWeek()->format('Y-m-d'),
+            'collected_by' => $this->registration->family->carers->first()->id,
+        ];
+
+        $response = $this->actingAs($this->centreUser, 'store')
+            ->visit($route)
+            ->put($putRoute, $data);
+
+        $response->seeInSession('error_messages');
+        $this->assertTrue($this->hasMatchingErrorMessage(
+            Session::get('error_messages'),
+            '/Action denied on empty bundle/',
+        ));
+
+        $this->followRedirects()
+            ->seePageIs($route)
+            ->assertResponseStatus(200);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
     /**
-     * Search the session's array of error messages for one that matches our regular expression.
+     * Search an array of session error messages for one matching the given regular expression.
+     * Handles both plain strings and HtmlString-derived arrays with a 'html' key.
      *
-     * @param (string|array)[] $errorMessages array
-     * @param string $regex
-     * @return bool whether a matching message was found or not
+     * @param array<int, string|array<string, string>> $errorMessages
      */
     private function hasMatchingErrorMessage(array $errorMessages, string $regex): bool
     {
         foreach ($errorMessages as $error) {
-            // If the error message is an array describing some HTML, extract the text, otherwise use as a string directly.
-            $string = is_array($error) && array_key_exists('html', $error) ? $error['html'] : $error;
+            $string = is_array($error) && array_key_exists('html', $error)
+                ? $error['html']
+                : (string)$error;
+
             if (preg_match($regex, $string)) {
                 return true;
             }
         }
+
         return false;
     }
 }

--- a/tests/Unit/Controllers/Store/BundleControllerTest.php
+++ b/tests/Unit/Controllers/Store/BundleControllerTest.php
@@ -256,43 +256,6 @@ class BundleControllerTest extends StoreTestCase
     }
 
     // -------------------------------------------------------------------------
-    // Sync (PUT)
-    // -------------------------------------------------------------------------
-
-    public function testICanSyncAnArrayOfVouchers(): void
-    {
-        $putRoute = route('store.registration.vouchers.put', ['registration' => $this->registration->id]);
-
-        // Sync a single voucher.
-        $this->actingAs($this->centreUser, 'store')
-            ->put($putRoute, ['vouchers' => [$this->testCodes[0]]]);
-
-        $currentBundle = $this->registration->currentBundle();
-        $this->assertSame(1, $currentBundle->vouchers()->count());
-
-        // Re-sync with all three vouchers.
-        $this->actingAs($this->centreUser, 'store')
-            ->put($putRoute, ['vouchers' => $this->testCodes]);
-
-        $currentBundle->refresh();
-        $this->assertSame(count($this->testCodes), $currentBundle->vouchers()->count());
-
-        // Sending no vouchers key at all leaves the bundle unchanged.
-        $this->actingAs($this->centreUser, 'store')
-            ->put($putRoute);
-
-        $currentBundle->refresh();
-        $this->assertSame(count($this->testCodes), $currentBundle->vouchers()->count());
-
-        // A single empty string in the vouchers array clears the bundle.
-        $this->actingAs($this->centreUser, 'store')
-            ->put($putRoute, ['vouchers' => ['']]);
-
-        $currentBundle->refresh();
-        $this->assertSame(0, $currentBundle->vouchers()->count());
-    }
-
-    // -------------------------------------------------------------------------
     // Delete operations
     // -------------------------------------------------------------------------
 

--- a/tests/Unit/FormRequests/StoreAppendBundleRequestTest.php
+++ b/tests/Unit/FormRequests/StoreAppendBundleRequestTest.php
@@ -19,6 +19,8 @@ class StoreAppendBundleRequestTest extends StoreTestCase
     protected CentreUser $centreUser;
     protected Registration $registration;
 
+    private const CODES = ['TST09999', 'TST10000', 'TST10001'];
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -39,7 +41,7 @@ class StoreAppendBundleRequestTest extends StoreTestCase
         // Auth context is required by the voucher state-machine transition logger.
         Auth::login($this->centreUser);
 
-        foreach (['TST09999', 'TST10000', 'TST10001'] as $code) {
+        foreach (self::CODES as $code) {
             $voucher = factory(Voucher::class)->state('printed')->create(['code' => $code]);
             $voucher->applyTransition('dispatch');
         }
@@ -125,6 +127,21 @@ class StoreAppendBundleRequestTest extends StoreTestCase
         ];
     }
 
+    public static function validInputCases(): array
+    {
+        return [
+            'voucher-quantity: maximum allowed value is accepted' => [
+                ['voucher-quantity' => ':max:'],
+            ],
+            'start: valid code without end is accepted' => [
+                ['start' => self::CODES[0]],
+            ],
+            'start and end: valid range is accepted' => [
+                ['start' => self::CODES[0], 'end' => self::CODES[2]],
+            ],
+        ];
+    }
+
     // -------------------------------------------------------------------------
     // Tests
     // -------------------------------------------------------------------------
@@ -158,5 +175,24 @@ class StoreAppendBundleRequestTest extends StoreTestCase
         $this->followRedirects()
             ->seePageIs($route)
             ->assertResponseStatus(200);
+    }
+
+    #[DataProvider('validInputCases')]
+    public function testValidInputIsAccepted(array $data): void
+    {
+        $max = (string)config('arc.bundle_max_voucher_append');
+
+        $data = array_map(static function (string $v) use ($max): string {
+            return str_replace(':max:', $max, $v);
+        }, $data);
+
+        $route = route('store.registration.voucher-manager', ['registration' => $this->registration->id]);
+        $postRoute = route('store.registration.vouchers.post', ['registration' => $this->registration->id]);
+
+        $this->actingAs($this->centreUser, 'store')
+            ->visit($route)
+            ->post($postRoute, $data);
+
+        $this->assertSessionMissing('errors');
     }
 }

--- a/tests/Unit/FormRequests/StoreAppendBundleRequestTest.php
+++ b/tests/Unit/FormRequests/StoreAppendBundleRequestTest.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace Tests\Unit\FormRequests;
+
+use App\Centre;
+use App\CentreUser;
+use App\Registration;
+use App\Voucher;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Auth;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\StoreTestCase;
+
+class StoreAppendBundleRequestTest extends StoreTestCase
+{
+    use RefreshDatabase;
+
+    protected Centre $centre;
+    protected CentreUser $centreUser;
+    protected Registration $registration;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->centre = factory(Centre::class)->create();
+
+        $this->centreUser = factory(CentreUser::class)->create([
+            'name' => 'test user',
+            'email' => 'testuser@example.com',
+            'password' => bcrypt('test_user_pass'),
+        ]);
+        $this->centreUser->centres()->attach($this->centre->id, ['homeCentre' => true]);
+
+        $this->registration = factory(Registration::class)->create([
+            'centre_id' => $this->centre->id,
+        ]);
+
+        // Auth context is required by the voucher state-machine transition logger.
+        Auth::login($this->centreUser);
+
+        foreach (['TST09999', 'TST10000', 'TST10001'] as $code) {
+            $voucher = factory(Voucher::class)->state('printed')->create(['code' => $code]);
+            $voucher->applyTransition('dispatch');
+        }
+
+        Auth::logout();
+    }
+
+    // -------------------------------------------------------------------------
+    // Data provider
+    // -------------------------------------------------------------------------
+
+    /**
+     * @return array<string, array{array<string,string>, string, string}>
+     * Config placeholders: config() is unavailable in static providers (they are constructed
+     * before the Laravel application boots). Two placeholders are used instead and resolved
+     * inside the test method once the container is live:
+     *   :max:          → config('arc.bundle_max_voucher_append')
+     *   :max_plus_one: → config('arc.bundle_max_voucher_append') + 1
+     */
+    public static function validationCases(): array
+    {
+        return [
+            // --- start field (voucher-quantity absent branch) ---
+            'start: absent with no data submitted' => [
+                [],
+                'start',
+                'The start field is required when voucher-quantity is not present.',
+            ],
+            'start: absent when only end supplied' => [
+                ['end' => 'tst10001'],
+                'start',
+                'The start field is required when voucher-quantity is not present.',
+            ],
+            'start: empty string stripped by prepareForValidation' => [
+                ['start' => '', 'end' => 'tst10001'],
+                'start',
+                'The start field is required when voucher-quantity is not present.',
+            ],
+            'start: value not found in vouchers table' => [
+                ['start' => 'invalidVoucher', 'end' => 'tst10001'],
+                'start',
+                'The selected start is invalid.',
+            ],
+
+            // --- end field ---
+            'end: value not found in vouchers table' => [
+                ['start' => 'tst09999', 'end' => 'invalidCode'],
+                'end',
+                'The selected end is invalid.',
+            ],
+            'end: different sponsor prefix to start' => [
+                ['start' => 'tst09999', 'end' => 'txt10000'],
+                'end',
+                'The end field must be the same sponsor as the start field.',
+            ],
+            'end: lower sequence number than start' => [
+                ['start' => 'tst10001', 'end' => 'tst09999'],
+                'end',
+                'The end field must be greater than the start field.',
+            ],
+
+            // --- voucher-quantity field (early-return branch) ---
+            'voucher-quantity: zero is below the allowed minimum of 1' => [
+                ['voucher-quantity' => '0'],
+                'voucher-quantity',
+                'The voucher-quantity must be between 1 and :max:.',
+            ],
+            'voucher-quantity: negative value is below the allowed minimum of 1' => [
+                ['voucher-quantity' => '-1'],
+                'voucher-quantity',
+                'The voucher-quantity must be between 1 and :max:.',
+            ],
+            'voucher-quantity: exceeds the configured maximum' => [
+                ['voucher-quantity' => ':max_plus_one:'],
+                'voucher-quantity',
+                'The voucher-quantity must be between 1 and :max:.',
+            ],
+            'voucher-quantity: required when start also absent' => [
+                [],
+                'voucher-quantity',
+                'The voucher-quantity field is required when start is not present.',
+            ],
+        ];
+    }
+
+    // -------------------------------------------------------------------------
+    // Tests
+    // -------------------------------------------------------------------------
+
+    #[DataProvider('validationCases')]
+    public function testInvalidInputIsRejected(
+        array $data,
+        string $field,
+        string $expectedMessage,
+    ): void {
+        $max = (string)config('arc.bundle_max_voucher_append');
+
+        // Resolve placeholders that cannot be evaluated inside a static data provider.
+        $data = array_map(static function (string $v) use ($max) {
+            return str_replace(':max_plus_one:', (string)((int)$max + 1), $v);
+        }, $data);
+        $expectedMessage = str_replace(':max:', $max, $expectedMessage);
+
+        $route = route('store.registration.voucher-manager', ['registration' => $this->registration->id]);
+        $postRoute = route('store.registration.vouchers.post', ['registration' => $this->registration->id]);
+
+        $this->actingAs($this->centreUser, 'store')
+            ->visit($route)
+            ->post($postRoute, $data);
+
+        $errors = session('errors')->get($field);
+
+        $this->assertNotEmpty($errors, "Expected validation errors for field '{$field}'");
+        $this->assertContains($expectedMessage, $errors);
+
+        $this->followRedirects()
+            ->seePageIs($route)
+            ->assertResponseStatus(200);
+    }
+}

--- a/tests/Unit/FormRequests/StorePickupBundleRequestTest.php
+++ b/tests/Unit/FormRequests/StorePickupBundleRequestTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\FormRequests;
 
+use App\Carer;
 use App\Centre;
 use App\CentreUser;
 use App\Registration;
@@ -9,7 +10,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\StoreTestCase;
 
-class StoreUpdateBundleRequestTest extends StoreTestCase
+class StorePickupBundleRequestTest extends StoreTestCase
 {
     use RefreshDatabase;
 
@@ -33,6 +34,8 @@ class StoreUpdateBundleRequestTest extends StoreTestCase
         $this->registration = factory(Registration::class)->create([
             'centre_id' => $this->centre->id,
         ]);
+
+        $this->carer = Carer::first();
     }
 
     // -------------------------------------------------------------------------
@@ -45,21 +48,24 @@ class StoreUpdateBundleRequestTest extends StoreTestCase
     public static function validationCases(): array
     {
         return [
-            'collected_by missing' => [
-                ['collected_at' => '1', 'collected_on' => '2018-07-21'],
-                'collected_by',
-                'The collected by field is required when collected at / collected on is present.',
-            ],
+            // --- required fields ---
             'collected_at missing' => [
-                ['collected_by' => '1', 'collected_on' => '2018-07-21'],
+                ['collected_on' => '2018-07-21', 'collected_by' => '1'],
                 'collected_at',
-                'The collected at field is required when collected on / collected by is present.',
+                'The collected at field is required.',
             ],
             'collected_on missing' => [
                 ['collected_at' => '1', 'collected_by' => '1'],
                 'collected_on',
-                'The collected on field is required when collected at / collected by is present.',
+                'The collected on field is required.',
             ],
+            'collected_by missing' => [
+                ['collected_at' => '1', 'collected_on' => '2018-07-21'],
+                'collected_by',
+                'The collected by field is required.',
+            ],
+
+            // --- format/existence ---
             'collected_on wrong date format' => [
                 ['collected_at' => '1', 'collected_on' => 'invalid', 'collected_by' => '1'],
                 'collected_on',
@@ -103,5 +109,22 @@ class StoreUpdateBundleRequestTest extends StoreTestCase
         $this->followRedirects()
             ->seePageIs($route)
             ->assertResponseStatus(200);
+    }
+
+    public function testValidInputIsAccepted(): void
+    {
+
+        $route = route('store.registration.voucher-manager', ['registration' => $this->registration->id]);
+        $putRoute = route('store.registration.vouchers.put', ['registration' => $this->registration->id]);
+
+        $this->actingAs($this->centreUser, 'store')
+            ->visit($route)
+            ->put($putRoute, [
+                'collected_at' => (string)$this->centre->id,
+                'collected_on' => '2018-07-21',
+                'collected_by' => (string)$this->carer->id,
+            ]);
+
+        $this->assertSessionMissing('errors');
     }
 }

--- a/tests/Unit/FormRequests/StoreTransitionBundleRequestTest.php
+++ b/tests/Unit/FormRequests/StoreTransitionBundleRequestTest.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Tests\Unit\FormRequests;
+
+use App\Carer;
+use App\Centre;
+use App\CentreUser;
+use App\Registration;
+use App\Trader;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\StoreTestCase;
+
+class StoreTransitionBundleRequestTest extends StoreTestCase
+{
+    use RefreshDatabase;
+
+    protected Centre $centre;
+    protected CentreUser $centreUser;
+    protected Registration $registration;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->centre = factory(Centre::class)->create();
+
+        $this->centreUser = factory(CentreUser::class)->create([
+            'name' => 'test user',
+            'email' => 'testuser@example.com',
+            'password' => bcrypt('test_user_pass'),
+        ]);
+        $this->centreUser->centres()->attach($this->centre->id, ['homeCentre' => true]);
+
+        $this->registration = factory(Registration::class)->create([
+            'centre_id' => $this->centre->id,
+        ]);
+
+        $this->carer = Carer::first();
+    }
+
+    // -------------------------------------------------------------------------
+    // Data provider
+    // -------------------------------------------------------------------------
+
+    /**
+     * @return array<string, array{array<string,string>, string, string}>
+     */
+    public static function validationCases(): array
+    {
+        return [
+            // --- required fields ---
+            'trader_id missing' => [
+                ['collected_at' => '1', 'collected_on' => '2018-07-21', 'collected_by' => '1'],
+                'trader_id',
+                'The trader id field is required.',
+            ],
+            'collected_at missing' => [
+                ['trader_id' => '1', 'collected_on' => '2018-07-21', 'collected_by' => '1'],
+                'collected_at',
+                'The collected at field is required.',
+            ],
+            'collected_on missing' => [
+                ['trader_id' => '1', 'collected_at' => '1', 'collected_by' => '1'],
+                'collected_on',
+                'The collected on field is required.',
+            ],
+            'collected_by missing' => [
+                ['trader_id' => '1', 'collected_at' => '1', 'collected_on' => '2018-07-21'],
+                'collected_by',
+                'The collected by field is required.',
+            ],
+
+            // --- format/existence ---
+            'collected_on wrong date format' => [
+                ['trader_id' => '1', 'collected_at' => '1', 'collected_on' => 'invalid', 'collected_by' => '1'],
+                'collected_on',
+                'The collected on does not match the format Y-m-d.',
+            ],
+            'collected_at centre does not exist' => [
+                ['trader_id' => '1', 'collected_at' => '9999', 'collected_on' => '2018-07-21', 'collected_by' => '1'],
+                'collected_at',
+                'The selected collected at is invalid.',
+            ],
+            'collected_by carer does not exist' => [
+                ['trader_id' => '1', 'collected_at' => '1', 'collected_on' => '2018-07-21', 'collected_by' => '9999'],
+                'collected_by',
+                'The selected collected by is invalid.',
+            ],
+            'trader_id trader does not exist' => [
+                ['trader_id' => '9999', 'collected_at' => '1', 'collected_on' => '2018-07-21', 'collected_by' => '1'],
+                'trader_id',
+                'The selected trader id is invalid.',
+            ],
+        ];
+    }
+
+    // -------------------------------------------------------------------------
+    // Tests
+    // -------------------------------------------------------------------------
+
+    #[DataProvider('validationCases')]
+    public function testInvalidInputIsRejected(
+        array $data,
+        string $field,
+        string $expectedMessage,
+    ): void {
+        $route = route('store.registration.voucher-manager', ['registration' => $this->registration->id]);
+        $postRoute = route(
+            'store.registration.vouchers.transitions.collect',
+            ['registration' => $this->registration->id]
+        );
+
+        $this->actingAs($this->centreUser, 'store')
+            ->visit($route)
+            ->post($postRoute, $data);
+
+        $errors = session('errors')->get($field);
+
+        $this->assertNotEmpty($errors, "Expected validation errors for field '{$field}'");
+        $this->assertContains($expectedMessage, $errors);
+
+        $this->followRedirects()
+            ->seePageIs($route)
+            ->assertResponseStatus(200);
+    }
+
+    public function testValidInputIsAccepted(): void
+    {
+        $trader = factory(Trader::class)->create();
+
+        $route = route('store.registration.voucher-manager', ['registration' => $this->registration->id]);
+        $postRoute = route(
+            'store.registration.vouchers.transitions.collect',
+            ['registration' => $this->registration->id]
+        );
+
+        $this->actingAs($this->centreUser, 'store')
+            ->visit($route)
+            ->post($postRoute, [
+                'trader_id' => (string)$trader->id,
+                'collected_at' => (string)$this->centre->id,
+                'collected_on' => '2018-07-21',
+                'collected_by' => (string)$this->carer->id,
+            ]);
+
+        $this->assertSessionMissing('errors');
+    }
+}

--- a/tests/Unit/FormRequests/StoreUpdateBundleRequestTest.php
+++ b/tests/Unit/FormRequests/StoreUpdateBundleRequestTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Tests\Unit\FormRequests;
+
+use App\Centre;
+use App\CentreUser;
+use App\Registration;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\StoreTestCase;
+
+class StoreUpdateBundleRequestTest extends StoreTestCase
+{
+    use RefreshDatabase;
+
+    protected Centre $centre;
+    protected CentreUser $centreUser;
+    protected Registration $registration;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->centre = factory(Centre::class)->create();
+
+        $this->centreUser = factory(CentreUser::class)->create([
+            'name' => 'test user',
+            'email' => 'testuser@example.com',
+            'password' => bcrypt('test_user_pass'),
+        ]);
+        $this->centreUser->centres()->attach($this->centre->id, ['homeCentre' => true]);
+
+        $this->registration = factory(Registration::class)->create([
+            'centre_id' => $this->centre->id,
+        ]);
+    }
+
+    // -------------------------------------------------------------------------
+    // Data provider
+    // -------------------------------------------------------------------------
+
+    /**
+     * @return array<string, array{array<string,string>, string, string}>
+     */
+    public static function validationCases(): array
+    {
+        return [
+            'collected_by missing' => [
+                ['collected_at' => '1', 'collected_on' => '2018-07-21'],
+                'collected_by',
+                'The collected by field is required when collected at / collected on is present.',
+            ],
+            'collected_at missing' => [
+                ['collected_by' => '1', 'collected_on' => '2018-07-21'],
+                'collected_at',
+                'The collected at field is required when collected on / collected by is present.',
+            ],
+            'collected_on missing' => [
+                ['collected_at' => '1', 'collected_by' => '1'],
+                'collected_on',
+                'The collected on field is required when collected at / collected by is present.',
+            ],
+            'collected_on wrong date format' => [
+                ['collected_at' => '1', 'collected_on' => 'invalid', 'collected_by' => '1'],
+                'collected_on',
+                'The collected on does not match the format Y-m-d.',
+            ],
+            'collected_at centre does not exist' => [
+                ['collected_at' => '9999', 'collected_on' => '2018-07-21', 'collected_by' => '1'],
+                'collected_at',
+                'The selected collected at is invalid.',
+            ],
+            'collected_by carer does not exist' => [
+                ['collected_at' => '1', 'collected_on' => '2018-07-21', 'collected_by' => '9999'],
+                'collected_by',
+                'The selected collected by is invalid.',
+            ],
+        ];
+    }
+
+    // -------------------------------------------------------------------------
+    // Tests
+    // -------------------------------------------------------------------------
+
+    #[DataProvider('validationCases')]
+    public function testInvalidInputIsRejected(
+        array $data,
+        string $field,
+        string $expectedMessage,
+    ): void {
+        $route = route('store.registration.voucher-manager', ['registration' => $this->registration->id]);
+        $putRoute = route('store.registration.vouchers.put', ['registration' => $this->registration->id]);
+
+        $this->actingAs($this->centreUser, 'store')
+            ->visit($route)
+            ->put($putRoute, $data);
+
+        $errors = session('errors')->get($field);
+
+        $this->assertNotEmpty($errors, "Expected validation errors for field '{$field}'");
+        $this->assertContains($expectedMessage, $errors);
+
+        $this->followRedirects()
+            ->seePageIs($route)
+            ->assertResponseStatus(200);
+    }
+}

--- a/tests/Unit/Models/StateTokenModelTest.php
+++ b/tests/Unit/Models/StateTokenModelTest.php
@@ -2,47 +2,180 @@
 
 namespace Tests\Unit\Models;
 
+use App\AdminUser;
 use App\StateToken;
+use App\User;
+use App\VoucherState;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\QueryException;
-use Ramsey\Uuid\Uuid;
-use Tests\TestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
 
 class StateTokenModelTest extends TestCase
 {
     use RefreshDatabase;
 
-
-    public function testItCanGenerateAPaymentUUID(): void
+    public function testFillableAttributes(): void
     {
-        // Create a StateToken
-        $token = factory(StateToken::class)->create();
+        $expected = ['uuid', 'user_id', 'admin_user_id'];
 
-        // Check it has a UUID that is valid;
-        $this->assertTrue(Uuid::isValid($token->uuid));
-
-        // Generate a new token with a specified value
-        $uuid = StateToken::generateUnusedToken();
-        $specifiedToken = factory(StateToken::class)->make(['uuid' => $uuid]);
-        $specifiedToken->save();
-
-        // See that saved correctly
-        $specifiedToken->fresh();
-        $this->assertEquals($uuid, $specifiedToken->uuid);
+        $this->assertSame($expected, (new StateToken())->getFillable());
     }
 
-
-    public function testItCannotSaveADuplicateUUID(): void
+    public function testGenerateUnusedTokenReturnsValidUuid(): void
     {
-        $this->expectExceptionMessage("Integrity constraint violation: 19 UNIQUE constraint failed: state_tokens.uuid");
-        $this->expectException(QueryException::class);
-        // Create a StateToken, should make a random, unique uuid
+        $token = StateToken::generateUnusedToken();
+
+        $this->assertTrue(Str::isUuid($token));
+    }
+
+    public function testGenerateUnusedTokenReturnsUniqueValues(): void
+    {
+        $first = StateToken::generateUnusedToken();
+        $second = StateToken::generateUnusedToken();
+
+        $this->assertNotSame($first, $second);
+    }
+
+    public function testGenerateUnusedTokenSkipsExistingUuids(): void
+    {
+        $existing = factory(StateToken::class)->create();
+
+        $fresh = (string)Str::uuid();
+        Str::createUuidsUsing(function () use ($existing, $fresh, &$called) {
+            if (!$called) {
+                $called = true;
+                return new class($existing->uuid) {
+                    public function __construct(private string $value)
+                    {
+                    }
+
+                    public function toString(): string
+                    {
+                        return $this->value;
+                    }
+
+                    public function __toString(): string
+                    {
+                        return $this->value;
+                    }
+                };
+            }
+            return new class($fresh) {
+                public function __construct(private string $value)
+                {
+                }
+
+                public function toString(): string
+                {
+                    return $this->value;
+                }
+
+                public function __toString(): string
+                {
+                    return $this->value;
+                }
+            };
+        });
+
+        $generated = StateToken::generateUnusedToken();
+
+        Str::createUuidsNormally();
+
+        $this->assertSame($fresh, $generated);
+        $this->assertNotSame($existing->uuid, $generated);
+    }
+
+    public function testCanCreateAndPersistTokenWithGeneratedUuid(): void
+    {
+        $uuid = StateToken::generateUnusedToken();
+        $token = factory(StateToken::class)->create(['uuid' => $uuid]);
+
+        $this->assertDatabaseHas('state_tokens', ['uuid' => $uuid]);
+        $this->assertSame($uuid, $token->fresh()->uuid);
+    }
+
+    public function testIsUsedTokenReturnsTrueForExistingUuid(): void
+    {
         $token = factory(StateToken::class)->create();
 
-        // Try to create a new token with the same value
-        // This will throw the above QueryException with the message substring specified
-        $token2 = factory(StateToken::class)->create(['uuid' => $token->uuid]);
+        $this->assertTrue(StateToken::isUsedToken($token->uuid));
+    }
 
-        $this->assertFalse($token2);
+    public function testIsUsedTokenReturnsFalseForUnknownUuid(): void
+    {
+        $this->assertFalse(StateToken::isUsedToken((string)Str::uuid()));
+    }
+
+    public function testDuplicateUuidThrowsQueryException(): void
+    {
+        $token = factory(StateToken::class)->create();
+
+        $this->expectException(QueryException::class);
+
+        factory(StateToken::class)->create(['uuid' => $token->uuid]);
+    }
+
+    public function testVoucherStatesIsHasManyRelation(): void
+    {
+        $relation = (new StateToken())->voucherStates();
+
+        $this->assertInstanceOf(HasMany::class, $relation);
+        $this->assertInstanceOf(VoucherState::class, $relation->getRelated());
+    }
+
+    public function testUserIsBelongsToRelation(): void
+    {
+        $relation = (new StateToken())->user();
+
+        $this->assertInstanceOf(BelongsTo::class, $relation);
+        $this->assertInstanceOf(User::class, $relation->getRelated());
+    }
+
+    public function testAdminUserIsBelongsToRelation(): void
+    {
+        $relation = (new StateToken())->adminUser();
+
+        $this->assertInstanceOf(BelongsTo::class, $relation);
+        $this->assertInstanceOf(AdminUser::class, $relation->getRelated());
+    }
+
+    public function testBelongsToUser(): void
+    {
+        $user = factory(User::class)->create();
+        $token = factory(StateToken::class)->create(['user_id' => $user->id]);
+
+        $this->assertTrue($token->user->is($user));
+    }
+
+    public function testBelongsToAdminUser(): void
+    {
+        $admin = factory(AdminUser::class)->create();
+        $token = factory(StateToken::class)->create(['admin_user_id' => $admin->id]);
+
+        $this->assertTrue($token->adminUser->is($admin));
+    }
+
+    public function testHasManyVoucherStates(): void
+    {
+        $token = factory(StateToken::class)->create();
+        factory(VoucherState::class, 3)->create(['state_token_id' => $token->id]);
+
+        $this->assertCount(3, $token->voucherStates);
+        $this->assertContainsOnlyInstancesOf(VoucherState::class, $token->voucherStates);
+    }
+
+    public function testUserIdAndAdminUserIdAreNullable(): void
+    {
+        $token = factory(StateToken::class)->create([
+            'user_id' => null,
+            'admin_user_id' => null,
+        ]);
+
+        $this->assertNull($token->user_id);
+        $this->assertNull($token->admin_user_id);
+        $this->assertDatabaseHas('state_tokens', ['id' => $token->id, 'user_id' => null]);
     }
 }


### PR DESCRIPTION
The goal here is to 
- streamline the process for _some_ centres who hand out vouchers and then walk to their own pantry and recoup them immediately as a "trader"
- we'll do this by letting them 
  a) pull from a pool of vouchers so they don't need to put in the first and last numbers.
  b) combine the handout and recollect function the system needs as a single event. 

## StoreBundleRequest
- can now cope with taking a voucher quantity OR the usual start/end combo

## Pickup and Collect blades
- have had some UX improvements
- are very similar, except Collect provides a Trader id, for the collection to pretend to be.
- (this trader id was provided by the centre having been set to collecting, and a listener on that event check/making at least one suitable trader)

## FormRequests
- form requests exist to validate the pickup and collect process
- there was an unneccesary check on vouchers in one request which was removed

## AppServiceProvider
- has a gate to prevent users not in centres performing actions they shouldn't
- (this will be used in later)

## Transition processor
This is code from the Trader facing app that does the normal job of transitioning the vouchers between states.
- it's now capable of handling calls from the centre user side that might provide a predefined set of vouchers, rather than having to resolve them from codes
- it had some utility functions added to say if there were errors and what codes it affected.

## Voucher Model
- got the ability to basically pick the next few un-bundled vouchers, so we don't have to specify vouchers by hand

## Bundle controller
  - has an function for simultaneously capturing handout and collection in a similar fashion to traders collecting vouchers.
  - this permits a centre user to act as a trader, and avoids actually handing vouchers to a family.
  - has had it's handout logic abstracted a bit so we can then reuse it for the "collecting" logic, as the system requires vouchers to be handed out before they can be collected in again. 

# On the way -

## Tests
- lots of tests :grimacing: 

## Statetoken
- got modernised, mostly to use laravel to produce v4 Uuids instead of poking Ramsey/Uuid directly.

## Store routes
- got moved about a bit by the refactors